### PR TITLE
Fix Crash when a grunt generated for an older instance of Covenant tries to connect back to a newer instance

### DIFF
--- a/Covenant/API/CovenantAPIExtensions.cs
+++ b/Covenant/API/CovenantAPIExtensions.cs
@@ -1031,7 +1031,14 @@ namespace Covenant.API
             /// </param>
             public static Grunt ApiGruntsByIdGet(this ICovenantAPI operations, int id)
             {
-                return operations.ApiGruntsByIdGetAsync(id).GetAwaiter().GetResult();
+                try
+                {
+                    return operations.ApiGruntsByIdGetAsync(id).GetAwaiter().GetResult();
+                }
+                catch
+                {
+                    return null;
+                }
             }
 
             /// <param name='operations'>


### PR DESCRIPTION
If you generate a launcher for an instance of Covenant, and then restart the Covenant instance and delete the old database, the new Instance of Covenant crashes when attempting to connect back with the old Grunt executable.

Steps to Recreate
- Start Covenant Server and set up a Listener
- Launchers > Generate > Binary
- Set ListenerName <listenerID>
- write test.exe
- Shut down Covenant Server
- Delete Covenant.db
- Start Covenant Server and set up a Listener on the same port.
- run test.exe