### PR TITLE
Add support for upstream reverse proxies

### DIFF
--- a/Covenant/Data/appsettings.json
+++ b/Covenant/Data/appsettings.json
@@ -2,5 +2,6 @@
   "JwtKey": "%cYA;YK,lxEFw[&P{2HwZ6Axr,{e&3o_}_P%NX+(q&0Ln^#hhft9gTdm'q%1ugAvfq6rC",
   "JwtIssuer": "Covenant",
   "JwtAudience":  "Covenant",
-  "JwtExpireDays":  100
+  "JwtExpireDays":  100,
+  "TrustedProxies": "127.0.0.1"
 }

--- a/Covenant/Startup.cs
+++ b/Covenant/Startup.cs
@@ -18,7 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
-
+using Microsoft.AspNetCore.HttpOverrides;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -27,6 +27,7 @@ using Covenant.API;
 using Covenant.Core;
 using Covenant.Models;
 using Covenant.Models.Covenant;
+using System.Net;
 
 namespace Covenant
 {
@@ -61,6 +62,10 @@ namespace Covenant
                 options.Lockout.AllowedForNewUsers = true;
 
                 options.User.RequireUniqueEmail = false;
+            });
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.KnownProxies.Add(IPAddress.Parse(Configuration["TrustedProxies"]));
             });
 
             services.ConfigureApplicationCookie(options =>
@@ -112,7 +117,6 @@ namespace Covenant
                 options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
             }).SetCompatibilityVersion(Microsoft.AspNetCore.Mvc.CompatibilityVersion.Version_2_2);
             services.AddRouting(options => options.LowercaseUrls = true);
-
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new Info { Title = "Covenant API", Version = "v0.1" });
@@ -152,6 +156,10 @@ namespace Covenant
                     return next();
                 });
             }
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
+            });
 
 			app.UseAuthentication();
 


### PR DESCRIPTION
This PR introduces a small configuration & code change that allows the Covenant UI to be placed behind a reverse proxy, and trust the headers that are supplied upstream. 