### PR TITLE
ToLower Method validation is incorrect

### DIFF
--- a/Covenant/Data/Tasks/CSharp/DCOM.task
+++ b/Covenant/Data/Tasks/CSharp/DCOM.task
@@ -11,8 +11,8 @@ public static class Task
             DCOM.DCOMMethod theMethod = DCOM.DCOMMethod.MMC20_Application;
             if (Method.ToLower() == "shellwindows") { theMethod = DCOM.DCOMMethod.ShellWindows; }
             else if (Method.ToLower() == "shellbrowserwindow") { theMethod = DCOM.DCOMMethod.ShellBrowserWindow; }
-            else if (Method.ToLower() == "ExcelDDE") { theMethod = DCOM.DCOMMethod.ExcelDDE; }
-            else if (Method.ToLower() != "MMC20_Application" && Method.ToLower() != "MMC20.Application") { return "DCOM Execution failed. Invalid DCOMMethod specified."; }
+            else if (Method.ToLower() == "exceldde") { theMethod = DCOM.DCOMMethod.ExcelDDE; }
+            else if (Method.ToLower() != "mmc20_application" && Method.ToLower() != "mmc20.application") { return "DCOM Execution failed. Invalid DCOMMethod specified."; }
 
             if (DCOM.DCOMExecute(ComputerName, Command, Parameters, Directory, theMethod))
             {


### PR DESCRIPTION
Because the ToLower function is called sending the Strings for ExcelDDE and MMC20.Application would never resolve to the correct DCOMMethod.