### PR TITLE
Add BypassAmsi Task

### DIFF
--- a/Covenant/Core/DbInitializer.cs
+++ b/Covenant/Core/DbInitializer.cs
@@ -1553,6 +1553,14 @@ namespace Covenant.Core
                     },
                     new GruntTask
                     {
+                        Name = "BypassAmsi",
+                        AlternateNames = new List<string>(),
+                        Description = "Bypasses AMSI by patching the AmsiScanBuffer function.",
+                        Code = File.ReadAllText(Path.Combine(Common.CovenantTaskCSharpDirectory, "BypassAmsi" + ".task")),
+                        Options = new List<GruntTaskOption>()
+                    },
+                    new GruntTask
+                    {
                         Name = "Set",
                         AlternateNames = new List<string>(),
                         Description = "Set a Grunt setting.",
@@ -1713,6 +1721,7 @@ namespace Covenant.Core
     new GruntTaskReferenceSourceLibrary { ReferenceSourceLibrary = ss, GruntTask = await context.GetGruntTaskByName("ShellCmd") },
     new GruntTaskReferenceSourceLibrary { ReferenceSourceLibrary = ss, GruntTask = await context.GetGruntTaskByName("PowerShell") },
     new GruntTaskReferenceSourceLibrary { ReferenceSourceLibrary = ss, GruntTask = await context.GetGruntTaskByName("Assembly") },
+    new GruntTaskReferenceSourceLibrary { ReferenceSourceLibrary = ss, GruntTask = await context.GetGruntTaskByName("BypassAmsi") },
     new GruntTaskReferenceSourceLibrary { ReferenceSourceLibrary = ss, GruntTask = await context.GetGruntTaskByName("AssemblyReflect") },
     new GruntTaskReferenceSourceLibrary { ReferenceSourceLibrary = ss, GruntTask = await context.GetGruntTaskByName("ListDirectory") },
     new GruntTaskReferenceSourceLibrary { ReferenceSourceLibrary = ss, GruntTask = await context.GetGruntTaskByName("ChangeDirectory") },

--- a/Covenant/Data/Tasks/CSharp/BypassAmsi.task
+++ b/Covenant/Data/Tasks/CSharp/BypassAmsi.task
@@ -1,0 +1,18 @@
+﻿using System;
+
+using SharpSploit.Evasion;
+
+public static class Task
+{
+    public static string Execute()
+    {
+        try
+        {
+            if (Amsi.PatchAmsiScanBuffer())
+            	return "Amsi Bypass Succeeded.";
+            else
+            	return "Amsi Bypass Failed.";
+        }
+        catch (Exception e) { return e.GetType().FullName + ": " + e.Message + Environment.NewLine + e.StackTrace; }
+    }
+}


### PR DESCRIPTION
Adds a `BypassAmsi` Task to utilise the new `AmsiScanBuffer` bypass in SharpSploit.
Don't merge until https://github.com/cobbr/SharpSploit/pull/25 has landed :)