### PR TITLE
Specify a range of ports for PortScan Task

### DIFF
--- a/Covenant/Core/DbInitializer.cs
+++ b/Covenant/Core/DbInitializer.cs
@@ -829,8 +829,8 @@ namespace Covenant.Core
                             {
                                 Id = 31,
                                 Name = "Ports",
-                                Description = "Ports to scan. Comma-delimited port list.",
-                                Value = "80,443,445",
+                                Description = "Ports to scan. Comma-delimited port list, use hyphens for port ranges",
+                                Value = "80,443-445,3389",
                                 SuggestedValues = new List<string>(),
                                 Optional = false,
                                 DisplayInCommand = true

--- a/Covenant/Data/Tasks/CSharp/PortScan.task
+++ b/Covenant/Data/Tasks/CSharp/PortScan.task
@@ -11,7 +11,21 @@ public static class Task
     {
         try
         {
-            List<int> portList = Ports.Split(',').Select(P => int.Parse(P)).ToList();
+            List<int> portList  = new List<int>();
+            foreach (string entry in Ports.Split(','))
+            {
+                if (entry.Contains("-"))
+                {
+                    string[] parts = entry.Split('-');
+                    int firstPort = int.Parse(parts[0]);
+                    int numPorts = int.Parse(parts[1]) - firstPort + 1;
+                    portList.AddRange(Enumerable.Range(firstPort, numPorts));
+                }
+                else
+                {
+                  portList.Add(int.Parse(entry));
+                }
+            }
             List<string> computerList = ComputerNames.Split(',').ToList();
             bool pingB = (Ping.ToLower() == "true" ? true : false);
             SharpSploitResultList<Network.PortScanResult> results = Network.PortScan(computerList, portList, pingB);


### PR DESCRIPTION
Allows ports to be submitted as ranges by including the starting port, a hyphen then the top port such as 8080-8090. 

This will complete feature request https://github.com/cobbr/Covenant/issues/88  "Specify a range of ports for PortScan Task"


 