### PR TITLE
Add Compression to Download Task

### DIFF
--- a/Covenant/Data/Tasks/CSharp/Download.task
+++ b/Covenant/Data/Tasks/CSharp/Download.task
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.IO.Compression;
 
 public static class Task
 {
@@ -7,7 +8,15 @@ public static class Task
     {
         try
         {
-            return Convert.ToBase64String(File.ReadAllBytes(FileName));
+            var fileBytes = File.ReadAllBytes(FileName);
+			using (var memoryStream = new MemoryStream())
+            {
+                using (var gZipStream = new GZipStream(memoryStream, CompressionMode.Compress, true))
+                {
+                    gZipStream.Write(fileBytes, 0, fileBytes.Length);
+                }
+                return Convert.ToBase64String(memoryStream.ToArray());
+            }
         }
         catch (Exception e) { return e.GetType().FullName + ": " + e.Message + Environment.NewLine + e.StackTrace; }
     }


### PR DESCRIPTION
This PR adds file compression to the `Download` Task.

However, I would prefer an alternative to https://github.com/rasta-mouse/Covenant/blob/download/Covenant/Models/Covenant/Event.cs#L60, where the `FileContents` of the download model is overwritten.