### PR TITLE
Use sdk image to run Covenant in Dockerfile

### DIFF
--- a/Covenant/Dockerfile
+++ b/Covenant/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . ./
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
 COPY ./Data ./Data


### PR DESCRIPTION
Dotnet SDK is required to compile Brute agent. When running with the current Dockerfile, the following error occures when trying to compile a Brute:
```
  It was not possible to find any installed .NET Core SDKs
  Did you mean to run .NET Core SDK commands? Install a .NET Core SDK from:
      https://aka.ms/dotnet-download
```
When changing image to SDK, everything is fine and the Brute is correctly generated
```
Microsoft (R) Build Engine version 16.6.0+5ff7b0c9e for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Restored /app/Data/Grunt/Brute/BruteStager/BruteStager.csproj (in 2.99 sec).
  BruteStager -> /app/Data/Grunt/Brute/BruteStager/bin/Release/netcoreapp3.1/win-x64/BruteStager.dll
  Optimizing assemblies for size, which may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
  BruteStager -> /app/Data/Grunt/Brute/BruteStager/bin/Release/netcoreapp3.1/win-x64/publish/
```

