### PR TITLE
Alternatives for ShellCmd and ShellCmdRunAs Tasks

### DIFF
--- a/Covenant/Data/Tasks/SharpSploit.Execution.yaml
+++ b/Covenant/Data/Tasks/SharpSploit.Execution.yaml
@@ -891,3 +891,226 @@
     EmbeddedResources: []
   ReferenceAssemblies: []
   EmbeddedResources: []
+- Name: ExecuteCmd
+  Aliases:
+  - cmd
+  Author:
+    Name: ''
+    Handle: kltdwd
+    Link: https://twitter.com/kltdwd
+  Description: Execute a command using "cmd.exe /c".
+  Help: 
+  Language: CSharp
+  CompatibleDotNetVersions:
+  - Net35
+  - Net40
+  Code: >
+    using System;
+
+    using SharpSploit.Execution;
+
+    public static class Task {
+        public static string Execute(string ShellCommand)
+        {
+            try
+            {
+               return Shell.Execute("cmd /c" + ShellCommand, false);
+            }
+            catch (Exception e) { return e.GetType().FullName + ": " + e.Message + Environment.NewLine + e.StackTrace; }
+        }
+    }
+  TaskingType: Assembly
+  UnsafeCompile: false
+  TokenTask: false
+  Options:
+  - Name: ShellCommand
+    Value: ''
+    DefaultValue: ''
+    Description: The ShellCommand to execute.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  ReferenceSourceLibraries:
+  - Name: SharpSploit
+    Description: SharpSploit is a library for C# post-exploitation modules.
+    Location: SharpSploit\
+    Language: CSharp
+    CompatibleDotNetVersions:
+    - Net35
+    - Net40
+    ReferenceAssemblies:
+    - Name: System.Management.dll
+      Location: net40\System.Management.dll
+      DotNetVersion: Net40
+    - Name: System.Management.Automation.dll
+      Location: net40\System.Management.Automation.dll
+      DotNetVersion: Net40
+    - Name: System.IdentityModel.dll
+      Location: net40\System.IdentityModel.dll
+      DotNetVersion: Net40
+    - Name: System.dll
+      Location: net40\System.dll
+      DotNetVersion: Net40
+    - Name: System.DirectoryServices.dll
+      Location: net40\System.DirectoryServices.dll
+      DotNetVersion: Net40
+    - Name: System.Core.dll
+      Location: net40\System.Core.dll
+      DotNetVersion: Net40
+    - Name: mscorlib.dll
+      Location: net40\mscorlib.dll
+      DotNetVersion: Net40
+    - Name: System.Windows.Forms.dll
+      Location: net35\System.Windows.Forms.dll
+      DotNetVersion: Net35
+    - Name: System.dll
+      Location: net35\System.dll
+      DotNetVersion: Net35
+    - Name: System.DirectoryServices.dll
+      Location: net35\System.DirectoryServices.dll
+      DotNetVersion: Net35
+    - Name: System.Core.dll
+      Location: net35\System.Core.dll
+      DotNetVersion: Net35
+    - Name: System.Windows.Forms.dll
+      Location: net40\System.Windows.Forms.dll
+      DotNetVersion: Net40
+    - Name: System.IdentityModel.dll
+      Location: net35\System.IdentityModel.dll
+      DotNetVersion: Net35
+    - Name: System.Management.Automation.dll
+      Location: net35\System.Management.Automation.dll
+      DotNetVersion: Net35
+    - Name: System.Management.dll
+      Location: net35\System.Management.dll
+      DotNetVersion: Net35
+    - Name: mscorlib.dll
+      Location: net35\mscorlib.dll
+      DotNetVersion: Net35
+    EmbeddedResources: []
+  ReferenceAssemblies: []
+  EmbeddedResources: []
+- Name: ExecuteCmdRunAs
+  Aliases:
+  - runas
+  Author:
+    Name: ''
+    Handle: kltdwd
+    Link: https://twitter.com/kltdwd
+  Description: Execute a command using "cmd.exe /c" as a specified user.
+  Help: ''
+  Language: CSharp
+  CompatibleDotNetVersions:
+  - Net35
+  - Net40
+  Code: >
+    using System;
+
+    using SharpSploit.Execution;
+
+    public static class Task {
+        public static string Execute(string Username, string Password, string Domain, string ShellCommand)
+        {
+            try
+            {
+               return Shell.Execute("cmd /c" + ShellCommand, Environment.SystemDirectory, false, Username, Domain, Password);
+            }
+            catch (Exception e) { return e.GetType().FullName + ": " + e.Message + Environment.NewLine + e.StackTrace; }
+        }
+    }
+  TaskingType: Assembly
+  UnsafeCompile: false
+  TokenTask: false
+  Options:
+  - Name: Username
+    Value: ''
+    DefaultValue: ''
+    Description: The username to execute as.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  - Name: Password
+    Value: ''
+    DefaultValue: ''
+    Description: The password to execute as.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  - Name: Domain
+    Value: ''
+    Description: The domain to execute as.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  - Name: ShellCommand
+    Value: ''
+    DefaultValue: ''
+    Description: The ShellCommand to execute.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  ReferenceSourceLibraries:
+  - Name: SharpSploit
+    Description: SharpSploit is a library for C# post-exploitation modules.
+    Location: SharpSploit\
+    Language: CSharp
+    CompatibleDotNetVersions:
+    - Net35
+    - Net40
+    ReferenceAssemblies:
+    - Name: System.Management.dll
+      Location: net40\System.Management.dll
+      DotNetVersion: Net40
+    - Name: System.Management.Automation.dll
+      Location: net40\System.Management.Automation.dll
+      DotNetVersion: Net40
+    - Name: System.IdentityModel.dll
+      Location: net40\System.IdentityModel.dll
+      DotNetVersion: Net40
+    - Name: System.dll
+      Location: net40\System.dll
+      DotNetVersion: Net40
+    - Name: System.DirectoryServices.dll
+      Location: net40\System.DirectoryServices.dll
+      DotNetVersion: Net40
+    - Name: System.Core.dll
+      Location: net40\System.Core.dll
+      DotNetVersion: Net40
+    - Name: mscorlib.dll
+      Location: net40\mscorlib.dll
+      DotNetVersion: Net40
+    - Name: System.Windows.Forms.dll
+      Location: net35\System.Windows.Forms.dll
+      DotNetVersion: Net35
+    - Name: System.dll
+      Location: net35\System.dll
+      DotNetVersion: Net35
+    - Name: System.DirectoryServices.dll
+      Location: net35\System.DirectoryServices.dll
+      DotNetVersion: Net35
+    - Name: System.Core.dll
+      Location: net35\System.Core.dll
+      DotNetVersion: Net35
+    - Name: System.Windows.Forms.dll
+      Location: net40\System.Windows.Forms.dll
+      DotNetVersion: Net40
+    - Name: System.IdentityModel.dll
+      Location: net35\System.IdentityModel.dll
+      DotNetVersion: Net35
+    - Name: System.Management.Automation.dll
+      Location: net35\System.Management.Automation.dll
+      DotNetVersion: Net35
+    - Name: System.Management.dll
+      Location: net35\System.Management.dll
+      DotNetVersion: Net35
+    - Name: mscorlib.dll
+      Location: net35\mscorlib.dll
+      DotNetVersion: Net35
+    EmbeddedResources: []
+  ReferenceAssemblies: []
+  EmbeddedResources: []


### PR DESCRIPTION
As mentioned on Slack :)

### ShellCmd

The current ShellCmd task currently runs, but output is not returned in Web UI or API. Believe this is attributed to recent update to SharpSploit v1.5

Screenshot below shows ls, shellcmd command (with no output) and then ls showing created file.

![Selection_025](https://user-images.githubusercontent.com/4188978/84320823-2abaf500-ab6a-11ea-89b3-c3ec90142477.png)

Existing 'ShellCmd' currently uses Sharpsploit.Execution calling `Shell.ShellCmdExecute(ShellCommand);`

Alternative task 'ExecuteCmd' uses Sharpsploit.Execution calling `Shell.Execute("cmd /c " + ShellCommand, false);`

![Selection_026](https://user-images.githubusercontent.com/4188978/84321553-4a9ee880-ab6b-11ea-9bf8-c8280d63e16b.png)

### ShellCmdRunAs

When running the current 'ShellCmdRunAs' task, the command errors with the following.

```
System.InvalidOperationException: The Process object must have the UseShellExecute property set to false in order to start a process as a user.
   at System.Diagnostics.Process.StartWithShellExecuteEx(ProcessStartInfo startInfo)
   at SharpSploit.Execution.Shell.Execute(String Command, String Path, Boolean UseShellExecute, String Username, String Domain, String Password)
   at Task.Execute(String ShellCommand, String Username, String Domain, String Password)
```

Proposing a fix with 'ExecuteCmdRunAs' task.

![Selection_027](https://user-images.githubusercontent.com/4188978/84320962-5e961a80-ab6a-11ea-9f5e-affa97636d1f.png)



