### PR TITLE
Update CredentialForm.razor

### DIFF
--- a/Covenant/Components/Credentials/CredentialForm.razor
+++ b/Covenant/Components/Credentials/CredentialForm.razor
@@ -68,7 +68,7 @@
             </div>
             <div class="form-group col-md-9">
                 <label for="Hash">Hash</label>
-                <input id="Hash" name="Hash" @bind="((CapturedHashCredential)Credential).Hash" class="form-control" disabled>
+                <input id="Hash" name="Hash" @bind="((CapturedHashCredential)Credential).Hash" class="form-control">
                 <div class="text-danger"><ValidationMessage For="() => ((CapturedHashCredential)Credential).Hash" /></div>
             </div>
         </div>


### PR DESCRIPTION
While creating Hash type credentials in Covenant the input field that accepts the Hash value is by default disabled. To fix it I have just removed the disabled attribute from the hash input field.