### PR TITLE
fix LINQ query

### DIFF
--- a/Covenant/Core/CovenantService.cs
+++ b/Covenant/Core/CovenantService.cs
@@ -2682,7 +2682,7 @@ namespace Covenant.Core
             }
             else if (tasking.GruntTask.Name.Equals("wmigrunt", StringComparison.OrdinalIgnoreCase))
             {
-                Launcher l = await _context.Launchers.FirstOrDefaultAsync(L => L.Name.Equals(parameters[1], StringComparison.OrdinalIgnoreCase));
+                Launcher l = _context.Launchers.AsEnumerable().FirstOrDefault(L => L.Name.Equals(parameters[1], StringComparison.OrdinalIgnoreCase));
                 if (l == null || l.LauncherString == null || l.LauncherString.Trim() == "")
                 {
                     throw new ControllerNotFoundException($"NotFound - Launcher with name: {parameters[1]}");
@@ -2702,7 +2702,7 @@ namespace Covenant.Core
             }
             else if (tasking.GruntTask.Name.Equals("dcomgrunt", StringComparison.OrdinalIgnoreCase))
             {
-                Launcher l = await _context.Launchers.FirstOrDefaultAsync(L => L.Name.Equals(parameters[1], StringComparison.OrdinalIgnoreCase));
+                Launcher l = _context.Launchers.AsEnumerable().FirstOrDefault(L => L.Name.Equals(parameters[1], StringComparison.OrdinalIgnoreCase));
                 if (l == null || l.LauncherString == null || l.LauncherString.Trim() == "")
                 {
                     throw new ControllerNotFoundException($"NotFound - Launcher with name: {parameters[1]}");
@@ -2726,7 +2726,7 @@ namespace Covenant.Core
             }
             else if (tasking.GruntTask.Name.Equals("powershellremotinggrunt", StringComparison.OrdinalIgnoreCase))
             {
-                Launcher l = await _context.Launchers.FirstOrDefaultAsync(L => L.Name.Equals(parameters[1], StringComparison.OrdinalIgnoreCase));
+                Launcher l = _context.Launchers.AsEnumerable().FirstOrDefault(L => L.Name.Equals(parameters[1], StringComparison.OrdinalIgnoreCase));
                 if (l == null || l.LauncherString == null || l.LauncherString.Trim() == "")
                 {
                     throw new ControllerNotFoundException($"NotFound - Launcher with name: {parameters[1]}");
@@ -2744,7 +2744,7 @@ namespace Covenant.Core
             }
             else if (tasking.GruntTask.Name.Equals("bypassuacgrunt", StringComparison.OrdinalIgnoreCase))
             {
-                Launcher l = await _context.Launchers.FirstOrDefaultAsync(L => L.Name.Equals(parameters[0], StringComparison.OrdinalIgnoreCase));
+                Launcher l = _context.Launchers.AsEnumerable().FirstOrDefault(L => L.Name.Equals(parameters[0], StringComparison.OrdinalIgnoreCase));
                 if (l == null || l.LauncherString == null || l.LauncherString.Trim() == "")
                 {
                     throw new ControllerNotFoundException($"NotFound - Launcher with name: {parameters[0]}");


### PR DESCRIPTION
Fix to issue 194
https://github.com/cobbr/Covenant/issues/194

This problem is caused by EF Core 3.0 and later.

https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#linq-queries-are-no-longer-evaluated-on-the-client

https://entityframeworkcore.com/knowledge-base/58166970/migrating-from-ef-core-2-to-ef-core-3

The cause of the exception is LINQ querying the Launcher.

```
Launcher l = await _context.Launchers.FirstOrDefaultAsync(L => L.Name.Equals(parameters[0], StringComparison.OrdinalIgnoreCase));
```

The problem can be solved by using AsEnumerable() to get the results of the query and then filtering afterwards, as shown below.

```
Launcher l = _context.Launchers.AsEnumerable().FirstOrDefault(L => L.Name.Equals(parameters[0], StringComparison.OrdinalIgnoreCase));
```

After the fix, BypassUACGrunt and PowerShellRemotingGrunt now work correctly.

![image](https://user-images.githubusercontent.com/2587857/89124701-ed446980-d513-11ea-9555-2563e61890e2.png)
