### PR TITLE
Specify Management Port

### DIFF
--- a/Covenant/Core/CovenantAPIService.cs
+++ b/Covenant/Core/CovenantAPIService.cs
@@ -26,7 +26,7 @@ namespace Covenant.Core
                 }
             };
             _client = new CovenantAPI(
-                new Uri("https://localhost:7443"),
+                new Uri($"https://localhost:{Common.CovenantHTTPSPort}"),
                 new TokenCredentials(configuration["ServiceUserToken"]),
                 clientHandler
             );

--- a/Covenant/Core/CovenantHubService.cs
+++ b/Covenant/Core/CovenantHubService.cs
@@ -33,7 +33,7 @@ namespace Covenant.Core
                 }
             };
             _connection = new HubConnectionBuilder()
-                .WithUrl("https://localhost:7443/covenantHub", options =>
+                .WithUrl($"https://localhost:{Common.CovenantHTTPSPort}/covenantHub", options =>
                 {
                     options.AccessTokenProvider = () => { return Task.FromResult(configuration["ServiceUserToken"]); };
                     options.HttpMessageHandlerFactory = inner =>

--- a/Covenant/Covenant.cs
+++ b/Covenant/Covenant.cs
@@ -55,6 +55,10 @@ namespace Covenant
                 "The ComputerName (IPAddress or Hostname) to bind the Covenant API to. (env: COVENANT_COMPUTER_NAME)",
                 CommandOptionType.SingleValue
             );
+            var PortOption = app.Option(
+                "-x | --port <PORT>",
+                "The Port to start the Covenant Listener on.",
+                CommandOptionType.SingleValue);
 
             app.OnExecute(() =>
             {
@@ -69,6 +73,8 @@ namespace Covenant
 
                 string username = UserNameOption.HasValue() ? UserNameOption.Value() : Environment.GetEnvironmentVariable("COVENANT_USERNAME");
                 string password = PasswordOption.HasValue() ? PasswordOption.Value() : Environment.GetEnvironmentVariable("COVENANT_PASSWORD");
+                Common.CovenantHTTPSPort = PortOption.HasValue() ? int.Parse(PortOption.Value()) : 7443;
+
                 if (!string.IsNullOrEmpty(username) && string.IsNullOrEmpty(password))
                 {
                     Console.Write("Password: ");

--- a/Covenant/Models/Listeners/InternalListener.cs
+++ b/Covenant/Models/Listeners/InternalListener.cs
@@ -110,13 +110,13 @@ namespace Covenant.Models.Listeners
                 }
             };
             _client = new CovenantAPI(
-                new Uri("https://localhost:7443"),
+                new Uri($"https://localhost:{Common.CovenantHTTPSPort}"),
                 new TokenCredentials(CovenantToken),
                 clientHandler
             );
 
             _connection = new HubConnectionBuilder()
-                .WithUrl("https://localhost:7443/gruntHub", options =>
+                .WithUrl($"https://localhost:{Common.CovenantHTTPSPort}/gruntHub", options =>
                 {
                     options.AccessTokenProvider = () => { return Task.FromResult(CovenantToken); };
                     options.HttpMessageHandlerFactory = inner =>


### PR DESCRIPTION
Added the ability to specify the management port when starting up covenant using the -x or the --port parameters (Since -p was already taken). This is to help close issue #144 