### PR TITLE
Payload Execution Guardrails - Environment Variable Checks

### DIFF
--- a/Covenant/API/Models/Grunt.cs
+++ b/Covenant/API/Models/Grunt.cs
@@ -40,7 +40,7 @@ namespace Covenant.API.Models
         /// 'Disconnected', 'Hidden'</param>
         /// <param name="integrity">Possible values include: 'Untrusted',
         /// 'Low', 'Medium', 'High', 'System'</param>
-        public Grunt(string name, string originalServerGuid, int implantTemplateId, bool validateCert, bool useCertPinning, string smbPipeName, int delay, int jitterPercent, int connectAttempts, System.DateTime killDate, DotNetVersion dotNetVersion, RuntimeIdentifier runtimeIdentifier, GruntStatus status, IntegrityLevel integrity, int? id = default(int?), string guid = default(string), IList<string> children = default(IList<string>), ImplantTemplate implantTemplate = default(ImplantTemplate), int? listenerId = default(int?), Listener listener = default(Listener), string note = default(string), string process = default(string), string userDomainName = default(string), string userName = default(string), string ipAddress = default(string), string hostname = default(string), string operatingSystem = default(string), string gruntSharedSecretPassword = default(string), string gruntRSAPublicKey = default(string), string gruntNegotiatedSessionKey = default(string), string gruntChallenge = default(string), System.DateTime? activationTime = default(System.DateTime?), System.DateTime? lastCheckIn = default(System.DateTime?), string powerShellImport = default(string), IList<GruntCommand> gruntCommands = default(IList<GruntCommand>))
+        public Grunt(string name, string originalServerGuid, int implantTemplateId, bool validateCert, bool useCertPinning, string smbPipeName, int delay, int jitterPercent, int connectAttempts, System.DateTime killDate, string guardrails, DotNetVersion dotNetVersion, RuntimeIdentifier runtimeIdentifier, GruntStatus status, IntegrityLevel integrity, int? id = default(int?), string guid = default(string), IList<string> children = default(IList<string>), ImplantTemplate implantTemplate = default(ImplantTemplate), int? listenerId = default(int?), Listener listener = default(Listener), string note = default(string), string process = default(string), string userDomainName = default(string), string userName = default(string), string ipAddress = default(string), string hostname = default(string), string operatingSystem = default(string), string gruntSharedSecretPassword = default(string), string gruntRSAPublicKey = default(string), string gruntNegotiatedSessionKey = default(string), string gruntChallenge = default(string), System.DateTime? activationTime = default(System.DateTime?), System.DateTime? lastCheckIn = default(System.DateTime?), string powerShellImport = default(string), IList<GruntCommand> gruntCommands = default(IList<GruntCommand>))
         {
             Id = id;
             Name = name;
@@ -59,6 +59,7 @@ namespace Covenant.API.Models
             JitterPercent = jitterPercent;
             ConnectAttempts = connectAttempts;
             KillDate = killDate;
+            Guardrails = guardrails;
             DotNetVersion = dotNetVersion;
             RuntimeIdentifier = runtimeIdentifier;
             Status = status;
@@ -169,6 +170,11 @@ namespace Covenant.API.Models
         /// </summary>
         [JsonProperty(PropertyName = "killDate")]
         public System.DateTime KillDate { get; set; }
+
+        /// <summary>
+        /// </summary>
+        [JsonProperty(PropertyName = "guardrails")]
+        public string Guardrails { get; set; }
 
         /// <summary>
         /// Gets or sets possible values include: 'Net35', 'Net40', 'NetCore31'

--- a/Covenant/API/Models/Launcher.cs
+++ b/Covenant/API/Models/Launcher.cs
@@ -39,7 +39,7 @@ namespace Covenant.API.Models
         /// 'ConsoleApplication', 'WindowsApplication',
         /// 'DynamicallyLinkedLibrary', 'NetModule', 'WindowsRuntimeMetadata',
         /// 'WindowsRuntimeApplication'</param>
-        public Launcher(int? id = default(int?), int? listenerId = default(int?), int? implantTemplateId = default(int?), string name = default(string), string description = default(string), LauncherType? type = default(LauncherType?), DotNetVersion? dotNetVersion = default(DotNetVersion?), RuntimeIdentifier? runtimeIdentifier = default(RuntimeIdentifier?), bool? validateCert = default(bool?), bool? useCertPinning = default(bool?), string smbPipeName = default(string), int? delay = default(int?), int? jitterPercent = default(int?), int? connectAttempts = default(int?), System.DateTime? killDate = default(System.DateTime?), string launcherString = default(string), string stagerCode = default(string), OutputKind? outputKind = default(OutputKind?), bool? compressStager = default(bool?))
+        public Launcher(int? id = default(int?), int? listenerId = default(int?), int? implantTemplateId = default(int?), string name = default(string), string description = default(string), LauncherType? type = default(LauncherType?), DotNetVersion? dotNetVersion = default(DotNetVersion?), RuntimeIdentifier? runtimeIdentifier = default(RuntimeIdentifier?), bool? validateCert = default(bool?), bool? useCertPinning = default(bool?), string smbPipeName = default(string), int? delay = default(int?), int? jitterPercent = default(int?), int? connectAttempts = default(int?), System.DateTime? killDate = default(System.DateTime?), string launcherString = default(string), string stagerCode = default(string), OutputKind? outputKind = default(OutputKind?), bool? compressStager = default(bool?), string guardrails)
         {
             Id = id;
             ListenerId = listenerId;
@@ -56,6 +56,7 @@ namespace Covenant.API.Models
             JitterPercent = jitterPercent;
             ConnectAttempts = connectAttempts;
             KillDate = killDate;
+            Guardrails = guardrails;
             LauncherString = launcherString;
             StagerCode = stagerCode;
             OutputKind = outputKind;
@@ -153,6 +154,11 @@ namespace Covenant.API.Models
         /// </summary>
         [JsonProperty(PropertyName = "killDate")]
         public System.DateTime? KillDate { get; set; }
+
+        /// <summary>
+        /// </summary>
+        [JsonProperty(PropertyName = "guardrails")]
+        public string guardrails { get; set; }
 
         /// <summary>
         /// </summary>

--- a/Covenant/API/Models/Launcher.cs
+++ b/Covenant/API/Models/Launcher.cs
@@ -39,7 +39,7 @@ namespace Covenant.API.Models
         /// 'ConsoleApplication', 'WindowsApplication',
         /// 'DynamicallyLinkedLibrary', 'NetModule', 'WindowsRuntimeMetadata',
         /// 'WindowsRuntimeApplication'</param>
-        public Launcher(int? id = default(int?), int? listenerId = default(int?), int? implantTemplateId = default(int?), string name = default(string), string description = default(string), LauncherType? type = default(LauncherType?), DotNetVersion? dotNetVersion = default(DotNetVersion?), RuntimeIdentifier? runtimeIdentifier = default(RuntimeIdentifier?), bool? validateCert = default(bool?), bool? useCertPinning = default(bool?), string smbPipeName = default(string), int? delay = default(int?), int? jitterPercent = default(int?), int? connectAttempts = default(int?), System.DateTime? killDate = default(System.DateTime?), string launcherString = default(string), string stagerCode = default(string), OutputKind? outputKind = default(OutputKind?), bool? compressStager = default(bool?), string guardrails)
+        public Launcher(int? id = default(int?), int? listenerId = default(int?), int? implantTemplateId = default(int?), string name = default(string), string description = default(string), LauncherType? type = default(LauncherType?), DotNetVersion? dotNetVersion = default(DotNetVersion?), RuntimeIdentifier? runtimeIdentifier = default(RuntimeIdentifier?), bool? validateCert = default(bool?), bool? useCertPinning = default(bool?), string smbPipeName = default(string), int? delay = default(int?), int? jitterPercent = default(int?), int? connectAttempts = default(int?), System.DateTime? killDate = default(System.DateTime?), string guardrails = default(string), string launcherString = default(string), string stagerCode = default(string), OutputKind? outputKind = default(OutputKind?), bool? compressStager = default(bool?))
         {
             Id = id;
             ListenerId = listenerId;
@@ -158,7 +158,7 @@ namespace Covenant.API.Models
         /// <summary>
         /// </summary>
         [JsonProperty(PropertyName = "guardrails")]
-        public string guardrails { get; set; }
+        public string Guardrails { get; set; }
 
         /// <summary>
         /// </summary>

--- a/Covenant/Components/Launchers/LauncherForm.razor
+++ b/Covenant/Components/Launchers/LauncherForm.razor
@@ -122,17 +122,17 @@
             <input id="ConnectAttempts" name="ConnectAttempts" @bind="Launcher.ConnectAttempts" class="form-control" type="number">
             <div class="text-danger"><ValidationMessage For="() => Launcher.ConnectAttempts" /></div>
         </div>
-        <div class="form-group col-md-3">
-            <label for="Guardrails">Guardrails</label>
-            <input id="Guardrails" name="Guardrails" @bind="Launcher.Guardrails" class="form-control">
-            <div class="text-danger"><ValidationMessage For="() => Launcher.Guardrails" /></div>
-        </div>
     </div>
     <div class="form-row">
         <div class="form-group col-md-3">
             <label for="KillDate">KillDate</label>
             <input id="KillDate" name="KillDate" @bind="Launcher.KillDate" class="form-control">
             <div class="text-danger"><ValidationMessage For="() => Launcher.KillDate" /></div>
+        </div>
+        <div class="form-group col-md-3">
+            <label for="Guardrails">Guardrails (envVar1=value1;envVar2=value2)</label>
+            <input id="Guardrails" name="Guardrails" @bind="Launcher.Guardrails" class="form-control">
+            <div class="text-danger"><ValidationMessage For="() => Launcher.Guardrails" /></div>
         </div>
     </div>
 

--- a/Covenant/Components/Launchers/LauncherForm.razor
+++ b/Covenant/Components/Launchers/LauncherForm.razor
@@ -122,6 +122,11 @@
             <input id="ConnectAttempts" name="ConnectAttempts" @bind="Launcher.ConnectAttempts" class="form-control" type="number">
             <div class="text-danger"><ValidationMessage For="() => Launcher.ConnectAttempts" /></div>
         </div>
+        <div class="form-group col-md-3">
+            <label for="Guardrails">Guardrails</label>
+            <input id="Guardrails" name="Guardrails" @bind="Launcher.Guardrails" class="form-control">
+            <div class="text-danger"><ValidationMessage For="() => Launcher.Guardrails" /></div>
+        </div>
     </div>
     <div class="form-row">
         <div class="form-group col-md-3">

--- a/Covenant/Core/CovenantService.cs
+++ b/Covenant/Core/CovenantService.cs
@@ -1623,6 +1623,7 @@ namespace Covenant.Core
                             .Replace("{{REPLACE_JITTER_PERCENT}}", this.FormatForVerbatimString(grunt.JitterPercent.ToString()))
                             .Replace("{{REPLACE_CONNECT_ATTEMPTS}}", this.FormatForVerbatimString(grunt.ConnectAttempts.ToString()))
                             .Replace("{{REPLACE_KILL_DATE}}", this.FormatForVerbatimString(grunt.KillDate.ToBinary().ToString()))
+                            .Replace("{{REPLACE_GUARDRAILS}}", grunt.Guardrails)
                             .Replace("{{REPLACE_GRUNT_SHARED_SECRET_PASSWORD}}", this.FormatForVerbatimString(grunt.GruntSharedSecretPassword));
                     }
                     else if (template.CommType == CommunicationType.SMB)

--- a/Covenant/Core/CovenantService.cs
+++ b/Covenant/Core/CovenantService.cs
@@ -4300,6 +4300,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -4347,6 +4348,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.StagerCode = launcher.StagerCode;
             _context.Launchers.Update(matchingLauncher);
@@ -4390,6 +4392,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -4437,6 +4440,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.StagerCode = launcher.StagerCode;
             _context.Launchers.Update(matchingLauncher);
@@ -4474,6 +4478,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -4521,6 +4526,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.StagerCode = launcher.StagerCode;
             matchingLauncher.ParameterString = launcher.ParameterString;
@@ -4561,6 +4567,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -4608,6 +4615,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.StagerCode = launcher.StagerCode;
             matchingLauncher.DiskCode = launcher.DiskCode;
@@ -4648,6 +4656,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -4695,6 +4704,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.DiskCode = launcher.DiskCode;
             matchingLauncher.StagerCode = launcher.StagerCode;
@@ -4733,6 +4743,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -4780,6 +4791,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.ScriptLanguage = launcher.ScriptLanguage;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.StagerCode = launcher.StagerCode;
@@ -4821,6 +4833,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -4868,6 +4881,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.ParameterString = launcher.ParameterString;
             matchingLauncher.DllName = launcher.DllName;
             matchingLauncher.ScriptLanguage = launcher.ScriptLanguage;
@@ -4913,6 +4927,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -4960,6 +4975,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.ScriptLanguage = launcher.ScriptLanguage;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.StagerCode = launcher.StagerCode;
@@ -5001,6 +5017,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -5048,6 +5065,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.ScriptLanguage = launcher.ScriptLanguage;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.StagerCode = launcher.StagerCode;
@@ -5089,6 +5107,7 @@ public static class Task
                 JitterPercent = launcher.JitterPercent,
                 ConnectAttempts = launcher.ConnectAttempts,
                 KillDate = launcher.KillDate,
+                Guardrails = launcher.Guardrails,
                 DotNetVersion = launcher.DotNetVersion,
                 RuntimeIdentifier = launcher.RuntimeIdentifier
             };
@@ -5136,6 +5155,7 @@ public static class Task
             matchingLauncher.JitterPercent = launcher.JitterPercent;
             matchingLauncher.ConnectAttempts = launcher.ConnectAttempts;
             matchingLauncher.KillDate = launcher.KillDate;
+            matchingLauncher.Guardrails = launcher.Guardrails;
             matchingLauncher.ScriptLanguage = launcher.ScriptLanguage;
             matchingLauncher.LauncherString = launcher.LauncherString;
             matchingLauncher.StagerCode = launcher.StagerCode;

--- a/Covenant/Data/Grunt/GruntHTTP/GruntHTTPStager.cs
+++ b/Covenant/Data/Grunt/GruntHTTP/GruntHTTPStager.cs
@@ -15,7 +15,6 @@ namespace GruntStager
         public GruntStager()
         {
             string Guardrails = @"{{REPLACE_GUARDRAILS}}";
-            	
 			if (EnvCheck(Guardrails)){
             ExecuteStager();
 			}

--- a/Covenant/Data/Grunt/GruntHTTP/GruntHTTPStager.cs
+++ b/Covenant/Data/Grunt/GruntHTTP/GruntHTTPStager.cs
@@ -15,9 +15,10 @@ namespace GruntStager
         public GruntStager()
         {
             string Guardrails = @"{{REPLACE_GUARDRAILS}}";
-			if (EnvCheck(Guardrails)){
-            ExecuteStager();
-			}
+            
+            if (EnvCheck(Guardrails)){
+                ExecuteStager();
+            }
         }
         [STAThread]
         public static void Main(string[] args)
@@ -211,27 +212,21 @@ namespace GruntStager
             catch (Exception e) { Console.Error.WriteLine(e.Message + Environment.NewLine + e.StackTrace); }
         }
 		
-         public static bool EnvCheck(string envString)
+        public bool EnvCheck(string envString)
         {
-            bool check = true;
             if (String.IsNullOrEmpty(envString))
             {
-                return check;
+                return true;
             }
             List<string> envSplitted = envString.Split(';').ToList<string>();
-
             foreach (string s in envSplitted)
             {
-                if (System.Environment.GetEnvironmentVariable(s.Split('=')[0]).Equals(s.Split('=')[1], StringComparison.InvariantCultureIgnoreCase))
+                if (!System.Environment.GetEnvironmentVariable(s.Split('=')[0]).Equals(s.Split('=')[1], StringComparison.InvariantCultureIgnoreCase))
                 {    
-                    check = check & true;
-                }
-                else
-                {
-                    return false;
+                   return false;
                 }
             }
-            return check;
+            return true;
         }
 		
 		

--- a/Covenant/Data/Grunt/GruntHTTP/GruntHTTPStager.cs
+++ b/Covenant/Data/Grunt/GruntHTTP/GruntHTTPStager.cs
@@ -14,11 +14,15 @@ namespace GruntStager
     {
         public GruntStager()
         {
+            string Guardrails = @"{{REPLACE_GUARDRAILS}}";
+            	
+			if (EnvCheck(Guardrails)){
             ExecuteStager();
+			}
         }
         [STAThread]
         public static void Main(string[] args)
-        {
+        {	
             new GruntStager();
         }
         public static void Execute()
@@ -207,7 +211,31 @@ namespace GruntStager
             }
             catch (Exception e) { Console.Error.WriteLine(e.Message + Environment.NewLine + e.StackTrace); }
         }
+		
+         public static bool EnvCheck(string envString)
+        {
+            bool check = true;
+            if (String.IsNullOrEmpty(envString))
+            {
+                return check;
+            }
+            List<string> envSplitted = envString.Split(';').ToList<string>();
 
+            foreach (string s in envSplitted)
+            {
+                if (System.Environment.GetEnvironmentVariable(s.Split('=')[0]).Equals(s.Split('=')[1], StringComparison.InvariantCultureIgnoreCase))
+                {    
+                    check = check & true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            return check;
+        }
+		
+		
         public class CookieWebClient : WebClient
         {
             public CookieContainer CookieContainer { get; private set; }

--- a/Covenant/Models/Grunts/Grunt.cs
+++ b/Covenant/Models/Grunts/Grunt.cs
@@ -75,6 +75,7 @@ namespace Covenant.Models.Grunts
         public int ConnectAttempts { get; set; } = 5000;
         [Required]
         public DateTime KillDate { get; set; } = DateTime.MaxValue;
+        public string Guardrails { get; set; } = "";
 
         // Attributes of the remote Grunt
         [Required]

--- a/Covenant/Models/Launchers/Launcher.cs
+++ b/Covenant/Models/Launchers/Launcher.cs
@@ -57,6 +57,7 @@ namespace Covenant.Models.Launchers
         public int JitterPercent { get; set; } = 10;
         public int ConnectAttempts { get; set; } = 5000;
         public DateTime KillDate { get; set; } = DateTime.Now.AddDays(30);
+	public string Guardrails { get; set; } = "";
         public string LauncherString { get; set; } = "";
         public string StagerCode { get; set; } = "";
 


### PR DESCRIPTION
### Why
Adversaries may use execution guardrails to constrain execution or actions based on adversary supplied and environment specific conditions that are expected to be present on the target. Guardrails ensure that a payload only executes against an intended target and reduces collateral damage from an adversary’s campaign ([more info](https://attack.mitre.org/techniques/T1480/)).

### Additions
This PR adds environment variable checks for the Grunt HTTP Stager before executing any of the stages.  The desired environment variables can be specified when creating a new HTTP launcher in the following format: 
`enVar1=value1;envVar2=value2;envVar3=value3....` 

Example: `USERNAME=ATTL4S;USERDOMAIN=SIMONE;LOGONSERVER=\\DC01`

If this form is empty, the Stager will just run without checking anything.

![envVar1](https://user-images.githubusercontent.com/35996395/94461934-12bfbd80-01bb-11eb-992c-097045bb8725.png)

### Future Work?
The way we implemented this has an obvious caveat: **all the logic is hardcoded in the Stager, so anyone will be able to see who is the actual target**. In addition, this implementation doesn't protect in any way the final payload, as anyone could bypass this env check and just jump to the stages and actual code.

- As we are using a Stager, we could leverage one of the stages to perform a server-side check of the variables so their values are not hardcoded in the actual Stager. If this check results in false, the server doesn't continue with further stages.
- For stageless payloads, we could encrypt the payload using those values (the only data harcoded would be the env var names to check)

Cheers!








