### PR TITLE
Configurable OutputKind for BinaryLauncher

### DIFF
--- a/Covenant/Components/Launchers/BinaryLauncherFormPartial.razor
+++ b/Covenant/Components/Launchers/BinaryLauncherFormPartial.razor
@@ -25,6 +25,7 @@
     protected override void OnInitialized()
     {
         this.BinaryLauncher = (BinaryLauncher)this.Launcher;
+        this.BinaryLauncher.OutputKind = (Microsoft.CodeAnalysis.OutputKind)typeof(Covenant.API.Models.OutputKind).GetField("WindowsApplication").GetValue(null);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/Covenant/Components/Launchers/BinaryLauncherFormPartial.razor
+++ b/Covenant/Components/Launchers/BinaryLauncherFormPartial.razor
@@ -1,5 +1,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Covenant.Models.Launchers
+@using Microsoft.JSInterop
+@inject IJSRuntime IJSRuntime
 
 <div class="form-group col-md-3">
 	<label for="OutputKind">OutputKind</label><br />
@@ -23,5 +25,10 @@
     protected override void OnInitialized()
     {
         this.BinaryLauncher = (BinaryLauncher)this.Launcher;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await IJSRuntime.InvokeAsync<string>("InitializeSelectPicker", new object[] { "#OutputKind.selectpicker", ((int)Enum.Parse(typeof(Covenant.API.Models.OutputKind), BinaryLauncher.OutputKind.ToString())).ToString() });
     }
 }

--- a/Covenant/Components/Launchers/BinaryLauncherFormPartial.razor
+++ b/Covenant/Components/Launchers/BinaryLauncherFormPartial.razor
@@ -1,0 +1,27 @@
+@using Microsoft.AspNetCore.Components.Forms
+@using Covenant.Models.Launchers
+
+<div class="form-group col-md-3">
+	<label for="OutputKind">OutputKind</label><br />
+	<select id="OutputKind" name="OutputKind" @bind="BinaryLauncher.OutputKind" class="selectpicker" data-width="auto">
+		@foreach (var n in Enum.GetNames(typeof(Covenant.API.Models.OutputKind)))
+		{
+			<option value="@(((Enum)typeof(Covenant.API.Models.OutputKind).GetField(n).GetValue(null)).ToString("d"))">@n</option>
+		}
+	</select>
+	<div class="text-danger"><ValidationMessage For="() => BinaryLauncher.OutputKind" /></div>
+</div>
+
+@code {
+    [Parameter]
+    public Launcher Launcher { get; set; }
+    public BinaryLauncher BinaryLauncher { get; set; }
+
+    [Parameter]
+    public EventCallback<Launcher> LauncherChanged { get; set; }
+
+    protected override void OnInitialized()
+    {
+        this.BinaryLauncher = (BinaryLauncher)this.Launcher;
+    }
+}

--- a/Covenant/Components/Launchers/BinaryLauncherFormPartial.razor
+++ b/Covenant/Components/Launchers/BinaryLauncherFormPartial.razor
@@ -25,7 +25,6 @@
     protected override void OnInitialized()
     {
         this.BinaryLauncher = (BinaryLauncher)this.Launcher;
-        this.BinaryLauncher.OutputKind = (Microsoft.CodeAnalysis.OutputKind)typeof(Covenant.API.Models.OutputKind).GetField("WindowsApplication").GetValue(null);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/Covenant/Components/Launchers/LauncherForm.razor
+++ b/Covenant/Components/Launchers/LauncherForm.razor
@@ -134,6 +134,7 @@
     @switch (Launcher.Name)
     {
         case "Binary":
+            <BinaryLauncherFormPartial @bind-Launcher="Launcher" />
             break;
         case "ShellCode":
             break;

--- a/Covenant/Models/Launchers/BinaryLauncher.cs
+++ b/Covenant/Models/Launchers/BinaryLauncher.cs
@@ -18,7 +18,6 @@ namespace Covenant.Models.Launchers
             this.Type = LauncherType.Binary;
             this.Description = "Uses a generated .NET Framework binary to launch a Grunt.";
             this.Name = "Binary";
-            this.OutputKind = OutputKind.ConsoleApplication;
             this.CompressStager = false;
         }
 

--- a/Covenant/Models/Launchers/BinaryLauncher.cs
+++ b/Covenant/Models/Launchers/BinaryLauncher.cs
@@ -18,6 +18,7 @@ namespace Covenant.Models.Launchers
             this.Type = LauncherType.Binary;
             this.Description = "Uses a generated .NET Framework binary to launch a Grunt.";
             this.Name = "Binary";
+            this.OutputKind = OutputKind.WindowsApplication;
             this.CompressStager = false;
         }
 


### PR DESCRIPTION
This PR creates an OutputKind form for the Binary Launcher to fix #49 
The default OutputKind is WindowsApplication (hidden window), so you don't have to choose it every time you generate a new Grunt.

![photo_2020-09-29_10-37-37](https://user-images.githubusercontent.com/35996395/94539941-2c5a1700-0246-11eb-91da-20c88cf3c7b7.jpg)