### PR TITLE
Don't read more than the expected number of bytes

### DIFF
--- a/Covenant/Data/Grunt/GruntBridge/GruntBridge.cs
+++ b/Covenant/Data/Grunt/GruntBridge/GruntBridge.cs
@@ -782,7 +782,7 @@ namespace GruntExecutor
                 int readBytes = 0;
                 do
                 {
-                    readBytes = this.Pipe.Read(buffer, 0, buffer.Length);
+                    readBytes = this.Pipe.Read(buffer, 0, Math.Min(len - totalReadBytes, buffer.Length));
                     ms.Write(buffer, 0, readBytes);
                     totalReadBytes += readBytes;
                 } while (totalReadBytes < len);

--- a/Covenant/Data/Grunt/GruntHTTP/GruntHTTP.cs
+++ b/Covenant/Data/Grunt/GruntHTTP/GruntHTTP.cs
@@ -810,7 +810,7 @@ namespace GruntExecutor
                 int readBytes = 0;
                 do
                 {
-                    readBytes = this.Pipe.Read(buffer, 0, buffer.Length);
+                    readBytes = this.Pipe.Read(buffer, 0, Math.Min(len - totalReadBytes, buffer.Length));
                     ms.Write(buffer, 0, readBytes);
                     totalReadBytes += readBytes;
                 } while (totalReadBytes < len);

--- a/Covenant/Data/Grunt/GruntSMB/GruntSMB.cs
+++ b/Covenant/Data/Grunt/GruntSMB/GruntSMB.cs
@@ -807,7 +807,7 @@ namespace GruntExecutor
                 int readBytes = 0;
                 do
                 {
-                    readBytes = this.Pipe.Read(buffer, 0, buffer.Length);
+                    readBytes = this.Pipe.Read(buffer, 0, Math.Min(len - totalReadBytes, buffer.Length));
                     ms.Write(buffer, 0, readBytes);
                     totalReadBytes += readBytes;
                 } while (totalReadBytes < len);

--- a/Covenant/Data/Grunt/GruntSMB/GruntSMBStager.cs
+++ b/Covenant/Data/Grunt/GruntSMB/GruntSMBStager.cs
@@ -176,7 +176,7 @@ namespace GruntStager
                 int readBytes = 0;
                 do
                 {
-                    readBytes = pipe.Read(buffer, 0, buffer.Length);
+                    readBytes = pipe.Read(buffer, 0, Math.Min(len - totalReadBytes, buffer.Length));
                     ms.Write(buffer, 0, readBytes);
                     totalReadBytes += readBytes;
                 } while (totalReadBytes < len);


### PR DESCRIPTION
SMBMessenger should never read more bytes than the length indicated in the message prefix. Take the minimum of the number of expected remaining bytes and the buffer length to avoid reading into the next message.

This fixes a bug where output from an SMB Grunt can be lost. To reproduce the issue:

1. Connect to an SMB Grunt
2. Issue a task that will produce a decent amount of output (e.g. `Rubeus triage`)
3. As soon as that shows as "tasked" submit another task (e.g. `pwd`)

The output for the task issued in step 3 will probably never be received because it's likely that the output was consumed as part of the response from the previous task.