### PR TITLE
Added Hide Grunt button

### DIFF
--- a/Covenant/Components/Grunts/GruntIndex.razor
+++ b/Covenant/Components/Grunts/GruntIndex.razor
@@ -17,7 +17,7 @@
     <h1 class="h2">Grunts</h1>
 </div>
 
-<GruntTable @bind-Grunts="Grunts" class="p-2" OnSelectTerminal="OnSelectTerminal">
+<GruntTable @bind-Grunts="Grunts" class="p-2" OnSelectTerminal="OnSelectTerminal" OnSubmit="OnEdit">
     <ButtonTray>
         @if (this.SomeHidden && this.Hidden)
         {
@@ -121,5 +121,20 @@
         this.Hidden = !this.Hidden;
         this.FilterGrunts();
         this.StateHasChanged();
+    }
+    
+    private async Task OnEdit(Grunt grunt)
+    {
+        try
+        {
+            AuthenticationState state = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            await Service.EditGrunt(grunt, await Service.GetCurrentUser(state.User));
+            Service.DisposeContext();
+            this.FilterGrunts();
+        }
+        catch (Exception e) when (e is ControllerNotFoundException || e is ControllerBadRequestException || e is ControllerUnauthorizedException)
+        {
+            // return RedirectToAction(nameof(Interact), new { id = grunt.Id });
+        }
     }
 }

--- a/Covenant/Components/Grunts/GruntTable.razor
+++ b/Covenant/Components/Grunts/GruntTable.razor
@@ -6,6 +6,7 @@
 @using Covenant.Core
 @using Covenant.Models.Grunts
 @using Covenant.Components.Shared
+@using Microsoft.AspNetCore.Components.Forms
 @inject IJSRuntime IJSRuntime
 @inject INotificationService INotificationService
 
@@ -44,6 +45,11 @@
         <SortableTableHeader TItem="Grunt" TItem2="string" GetSortableProperty="(grunt) => grunt.ImplantTemplate?.Name">
             <HeaderContent>Template</HeaderContent>
         </SortableTableHeader>
+        <th class="pl-1 pr-1">
+            <div class="secondary-color">
+               <span class="fe fe-eye"></span>
+            </div>
+        </th>
     </TableHeader>
     <TableRow Context="grunt">
         <tr style="opacity: @GetGruntStatusOpacity(grunt.Status)">
@@ -67,6 +73,20 @@
             <td @attributes="InputAttributes">@grunt.Status</td>
             <td @attributes="InputAttributes">@grunt.Note</td>
             <td @attributes="InputAttributes">@grunt.ImplantTemplate?.Name</td>
+            <td @attributes="InputAttributes">
+					@if (grunt.Status == GruntStatus.Hidden)
+					{
+						<button type="button" @onclick="e => OnUnhide(grunt)"  class="btn btn-success ml-2" style="padding: 0 0.5em 0 0.5em">
+							<span class="fe fe-eye"></span>
+						</button>
+					}
+					else
+					{
+						<button type="button" @onclick="e => OnHide(grunt)"  class="btn btn-warning ml-2" style="padding: 0 0.5em 0 0.5em">
+							<span class="fe fe-eye-off"></span>
+						</button>
+					}
+            </td>
         </tr>
     </TableRow>
     <ButtonTray>@ButtonTray</ButtonTray>
@@ -93,6 +113,9 @@
 
     [Parameter]
     public EventCallback<Grunt> OnSelectTerminal { get; set; }
+    
+    [Parameter]
+    public EventCallback<Grunt> OnSubmit { get; set; }
 
     [Parameter]
     public RenderFragment ButtonTray { get; set; }
@@ -130,4 +153,18 @@
             grunt.OperatingSystem.Contains(SearchTerm, StringComparison.CurrentCultureIgnoreCase) ||
             grunt.Process.Contains(SearchTerm, StringComparison.CurrentCultureIgnoreCase);
     }
+    
+
+    private async Task OnHide(Grunt grunt)
+    {
+        grunt.Status = GruntStatus.Hidden;
+        await this.OnSubmit.InvokeAsync(grunt);
+    }
+
+    private async Task OnUnhide(Grunt grunt)
+    {
+		grunt.Status = GruntStatus.Lost;
+        await this.OnSubmit.InvokeAsync(grunt);
+    }
+    
 }

--- a/Covenant/Components/Home/Dashboard.razor
+++ b/Covenant/Components/Home/Dashboard.razor
@@ -5,6 +5,8 @@
 @inherits OwningComponentBase<ICovenantService>
 @implements IDisposable
 
+@using Microsoft.AspNetCore.Components.Authorization
+
 @using Covenant.Core
 @using Covenant.Models.Grunts
 @using Covenant.Models.Listeners
@@ -12,6 +14,7 @@
 @using Covenant.Components.Grunts
 @using Covenant.Components.GruntTaskings
 @inject INotificationService INotificationService
+@inject AuthenticationStateProvider AuthenticationStateProvider
 
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3">
     <h1 class="h2">Dashboard</h1>
@@ -20,7 +23,7 @@
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center">
     <h4 class="h5">Grunts</h4>
 </div>
-<GruntTable @bind-Grunts="Grunts" IsPaginated="true" PageLength="10" IsSearchable="false" />
+<GruntTable @bind-Grunts="Grunts" IsPaginated="true" PageLength="10" IsSearchable="false" OnSubmit="OnEdit" />
 <br />
 
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center">
@@ -115,4 +118,18 @@
             this.InvokeAsync(() => this.StateHasChanged());
         }
     }
+    
+    private async Task OnEdit(Grunt grunt)
+    {
+        try
+        {
+            AuthenticationState state = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            await Service.EditGrunt(grunt, await Service.GetCurrentUser(state.User));
+            Service.DisposeContext();
+        }
+        catch (Exception e) when (e is ControllerNotFoundException || e is ControllerBadRequestException || e is ControllerUnauthorizedException)
+        {
+            // return RedirectToAction(nameof(Interact), new { id = grunt.Id });
+        }
+    }    
 }


### PR DESCRIPTION
Grunts can now be hidden from Dashboard and Grunt pages directly, so there is no need to access each Lost Grunt one by one to clear the Grunt table.

Dashboard page:
![imagen](https://user-images.githubusercontent.com/12718585/98165444-370f6800-1ee6-11eb-9075-8558b471c679.png)

Grunt page:
![imagen](https://user-images.githubusercontent.com/12718585/98165354-0d564100-1ee6-11eb-82b4-63fe08c868a4.png)
