### PR TITLE
Remove default values from api profiles

### DIFF
--- a/Covenant/Components/Profiles/HttpProfileForm.razor
+++ b/Covenant/Components/Profiles/HttpProfileForm.razor
@@ -9,6 +9,18 @@
 @inject IJSRuntime IJSRuntime
 @inject AuthenticationStateProvider AuthenticationStateProvider
 
+@if (Profile.HttpUrls.Count == 0) {
+        Profile.HttpUrls = new List<string> { "/index.html?id={GUID}" };
+}
+
+@if (Profile.HttpRequestHeaders.Count == 0 ) {
+    Profile.HttpRequestHeaders = new List<HttpProfileHeader> { new HttpProfileHeader { Name = "User-Agent", Value = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36" } };
+}
+
+@if (Profile.HttpResponseHeaders.Count == 0 ) {
+    Profile.HttpResponseHeaders = new List<HttpProfileHeader> { new HttpProfileHeader { Name = "Server", Value = "Microsoft-IIS/8.5" } };
+}
+
 <EditForm Model="Profile" OnValidSubmit="(e => this.OnSubmit.InvokeAsync(this.Profile))">
     <DataAnnotationsValidator />
     <div class="form-row">

--- a/Covenant/Models/Listeners/Profile.cs
+++ b/Covenant/Models/Listeners/Profile.cs
@@ -126,9 +126,9 @@ public class BridgeMessenger : IMessenger
 
     public class HttpProfile : Profile
     {
-        public List<string> HttpUrls { get; set; } = new List<string> { "/index.html?id={GUID}" };
-        public virtual List<HttpProfileHeader> HttpRequestHeaders { get; set; } = new List<HttpProfileHeader> { new HttpProfileHeader { Name = "User-Agent", Value = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36" } };
-        public virtual List<HttpProfileHeader> HttpResponseHeaders { get; set; } = new List<HttpProfileHeader> { new HttpProfileHeader { Name = "Server", Value = "Microsoft-IIS/7.5" } };
+        public List<string> HttpUrls { get; set; } = new List<string> { };
+        public virtual List<HttpProfileHeader> HttpRequestHeaders { get; set; } = new List<HttpProfileHeader> { };
+        public virtual List<HttpProfileHeader> HttpResponseHeaders { get; set; } = new List<HttpProfileHeader> { };
 
         public string HttpPostRequest { get; set; } = @"{DATA}";
         public string HttpGetResponse { get; set; } = @"{DATA}";


### PR DESCRIPTION
**Issue**
When trying to create listener profiles via the Swagger_UI, the default values in "Profile.cs" get applied regardless of what is supplied within the Swagger_UI.
This is not an issue within the native (web/websocket) UI. 

**Steps to Validate**
E.g. for a Covenant instance running on "[https://kali:7443/](https://kali:7443/)" you can access the Swagger UI at "[https://kali:7443/swagger/](https://kali:7443/swagger/)", authenticate and set your Bearer to allow other commands. 

1. Authenticate!
2. Use "GET /api/profiles/http/{id}" with the ID = 1 to get the "DefaultHttpProfile" - copy the JSON response
3. Use "PUT /api/profiles/http" and the copied JSON code to update the "DefaultHttpProfile" 
4. See that the URLs, Response and Request headers now have default values applied that were not in the configuration supplied to the API.

**Why a problem?**
If two listeners use the same default value for URL they end up conflicting over requests to that URL end point, this makes existing GRUNTS go offline (LOST) and new GRUNTS are unstable until the conflict is resolved.

**Proposed Fix**

1. Remove Default values from "Profile.cs", this allows the API to behave as expected, however it also breaks the WebUI as you can create a listener with no sane defaults. 
2. Move the Default values into the HttpProfileForm.razor HTML template, such that when creating a new profile (and therefore the Lists for HttpURLs and Requests / Responses are empty) sane defaults get applied.

**Testing Conducted**

1. That the Swagger_API can create listener profiles that matched supplied configuration.
2. That the Web_UI can create listener profiles with sane default values.
3. That Listeners can be created using newly created profiles
4. That GRUNTS can connect to this Listeners using new profiles.