### PR TITLE
Dev Branch: Docker configuration updated to work with Covenant.API.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 Dockerfile*
 **/*.trx
 **/*.md
+**/.git*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN dotnet publish -c Release -o out
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
-COPY ./Data ./Data
+COPY ./Covenant/Data ./Data
 EXPOSE 7443 80 443
 ENTRYPOINT ["dotnet", "Covenant.dll"]


### PR DESCRIPTION
I believe that when you separated the API (Covenant/API move to Covenant.API) you broke the docker build process. In its current state a docker build would fail because the Covenant.API project cannot be found (due to it not being copied). To fix this I brought the docker files up one directory and modified them to make everything work. I've tested these changes locally and everything seems to build as expected now.

It should be noted that you will need to update the "Installation and Startup" wiki on the next release to reflect that docker builds would now be from the "Covenant" directory and not the "Covenant/Covenant" directory.