### PR TITLE
[dev] Potential fix to Grunts not being deleted

### DIFF
--- a/Covenant/Models/CovenantContext.cs
+++ b/Covenant/Models/CovenantContext.cs
@@ -107,7 +107,9 @@ namespace Covenant.Models
 
             builder.Entity<Grunt>()
                 .HasMany(G => G.FolderRoots)
-                .WithOne(F => F.RootGrunt);
+                //.WithOne(F => F.RootGrunt);
+                .WithOne(F => F.RootGrunt)
+                .OnDelete(DeleteBehavior.Cascade);
             
             builder.Entity<FolderFileNode>()
                 .HasOne(N => N.Grunt)
@@ -117,7 +119,9 @@ namespace Covenant.Models
             builder.Entity<Folder>()
                 .HasMany(F => F.Nodes)
                 .WithOne()
-                .HasForeignKey(N => N.ParentId);
+                //.HasForeignKey(N => N.ParentId);
+                .HasForeignKey(N => N.ParentId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             builder.Entity<GruntTask>()
                 .HasOne(GT => GT.Author)


### PR DESCRIPTION
# TLDR
Fixes an error in Covenant's database schema that led to Grunts that could not be deleted anymore. I tested the fix a bit and have not seen any negative impact.

# Explanation
Sometimes, I was unable to delete a Grunt from the list via the Action dropdown. The following error was shown in the console:
```
fail: Microsoft.EntityFrameworkCore.Database.Command[20102]
      Failed executing DbCommand (1ms) [Parameters=[@p0='77' (DbType = String)], CommandType='Text', CommandTimeout='30']
      DELETE FROM "Folders"
      WHERE "Id" = @p0;
      SELECT changes();
```
I found that this was always the case when I used the file explorer in a Grunt. Looking at the database, two constraints caught my eye.  
Table "FolderFileNodes":
`CONSTRAINT "FK_FolderFileNodes_Folders_ParentId" FOREIGN KEY ("ParentId") REFERENCES "Folders" ("Id") ON DELETE RESTRICT,`  
Table "Folders":
`CONSTRAINT "FK_Folders_Grunts_RootGruntId" FOREIGN KEY ("RootGruntId") REFERENCES "Grunts" ("Id") ON DELETE RESTRICT,`  
I modified CovenantContext.cs so that the constraints were set to cascade on deletion.
Line 108-124:
```
            builder.Entity<Grunt>()
                .HasMany(G => G.FolderRoots)
                //.WithOne(F => F.RootGrunt);
                .WithOne(F => F.RootGrunt)
                .OnDelete(DeleteBehavior.Cascade);
            
            builder.Entity<FolderFileNode>()
                .HasOne(N => N.Grunt)
                .WithMany(G => G.FolderFileNodes)
                .HasForeignKey(N => N.GruntId);

            builder.Entity<Folder>()
                .HasMany(F => F.Nodes)
                .WithOne()
                //.HasForeignKey(N => N.ParentId);
                .HasForeignKey(N => N.ParentId)
                .OnDelete(DeleteBehavior.Cascade);
```
I had to create a new covenant.db, since I could not modify the constraints on the existing database tables. After the change, I was able to use the file explorer in my Grunts and then also successfully delete them.